### PR TITLE
Drift chamber digitized hit in global coordinate 

### DIFF
--- a/ARCdigi/include/ARCdigitizer.h
+++ b/ARCdigi/include/ARCdigitizer.h
@@ -11,14 +11,22 @@
 
 // EDM4HEP
 #include "edm4hep/SimTrackerHitCollection.h"
+#include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
 
 // DD4HEP
 #include "DD4hep/Detector.h"
 
 /** @class ARCdigitizer
  *
- *  Algorithm for creating digitized (meaning 'reconstructed' for now) ARC hits (edm4hep::TrackerHit) from Geant4 hits (edm4hep::SimTrackerHit).
+ *  Algorithm for creating digitized (meaning 'reconstructed' for now) ARC hits (edm4hep::TrackerHit3D) from Geant4 hits (edm4hep::SimTrackerHit).
  *  
  *  @author Brieuc Francois, Matthew Basso
  *  @date   2023-03
@@ -46,7 +54,7 @@ private:
   // Input sim tracker hit collection name
   DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  DataHandle<edm4hep::TrackerHitCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
   // Flat value for SiPM efficiency
   FloatProperty m_flat_SiPM_effi{this, "flatSiPMEfficiency", -1.0, "Flat value for SiPM quantum efficiency (<0 := disabled)"};
   // Apply the SiPM efficiency to digitized hits instead of simulated hits

--- a/ARCdigi/src/ARCdigitizer.cpp
+++ b/ARCdigi/src/ARCdigitizer.cpp
@@ -68,7 +68,7 @@ StatusCode ARCdigitizer::execute() {
   dd4hep::rec::CellIDPositionConverter converter(*m_detector);
 
   // Write the digitized hits
-  edm4hep::TrackerHitCollection* output_digi_hits = m_output_digi_hits.createAndPut();
+  edm4hep::TrackerHit3DCollection* output_digi_hits = m_output_digi_hits.createAndPut();
   for (auto it = merged_digi_hits.begin(); it != merged_digi_hits.end(); it++) {
     // Throw away digitized hits based on flat SiPM efficiency
     if (m_apply_SiPM_effi_to_digi && m_flat_SiPM_effi >= 0.0 && m_uniform.shoot() > m_flat_SiPM_effi)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(${PackageName})
 
 # please keep this layout for version setting, used by the automatic tagging script
 set(${PackageName}_VERSION_MAJOR 0)
-set(${PackageName}_VERSION_MINOR 1)
+set(${PackageName}_VERSION_MINOR 2)
 set(${PackageName}_VERSION_PATCH 0)
 
 set(${PackageName}_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")

--- a/DCHdigi/dataFormatExtension/driftChamberHit.yaml
+++ b/DCHdigi/dataFormatExtension/driftChamberHit.yaml
@@ -22,7 +22,7 @@ datatypes:
       - uint32_t clusterCount         // number of clusters associated to this hit
 
   extension::DriftChamberDigi:
-    Description: "Drift chamber digitized hit (before tracking) in global coordinates"
+    Description: "Drift chamber digitized hit (before tracking) in global coordinates. Assumes that the hits are radially in the middle of the cells"
     Author: "B. Francois, CERN"
     Members:
       - uint64_t cellID               // ID of the wire that created this hit

--- a/DCHdigi/dataFormatExtension/driftChamberHit.yaml
+++ b/DCHdigi/dataFormatExtension/driftChamberHit.yaml
@@ -32,3 +32,12 @@ datatypes:
       - float eDep                    // energy deposited on the hit [GeV].
       - float eDepError               // error measured on eDep [GeV].
       - uint32_t clusterCount         // number of clusters associated to this hit
+
+  extension::MCRecoDriftChamberDigiAssociation:
+    Description: "Association between a DriftChamberDigi and the corresponding simulated hit"
+    Author: "B. Francois, CERN"
+    Members:
+      - float weight              // weight of this association
+    OneToOneRelations:
+      - extension::DriftChamberDigi digi    // reference to the digitized hit
+      - edm4hep::SimTrackerHit sim // reference to the simulated hit

--- a/DCHdigi/dataFormatExtension/driftChamberHit.yaml
+++ b/DCHdigi/dataFormatExtension/driftChamberHit.yaml
@@ -9,7 +9,7 @@ options:
 
 datatypes:
 
-  extension::DriftChamberDigi:
+  extension::DriftChamberDigiLocal:
     Description: "Drift chamber digitized hit (before tracking) in local coordinates"
     Author: "B. Francois, CERN"
     Members:
@@ -21,13 +21,13 @@ datatypes:
       - float eDepError               // error measured on eDep [GeV].
       - uint32_t clusterCount         // number of clusters associated to this hit
 
-  extension::DriftChamberDigiLeftRightGlobal:
-    Description: "Drift chamber digitized hit (before tracking) in local coordinates"
+  extension::DriftChamberDigi:
+    Description: "Drift chamber digitized hit (before tracking) in global coordinates"
     Author: "B. Francois, CERN"
     Members:
       - uint64_t cellID               // ID of the wire that created this hit
-      - edm4hep::Vector3d leftPosition // position of the hit assuming it was on the left side of the wire [mm]
-      - edm4hep::Vector3d rightPosition // position of the hit assuming it was on the right side of the wire [mm]
+      - edm4hep::Vector3d leftPosition // position of the hit assuming it was on the left side of the wire, radially in the middle of the cell [mm]
+      - edm4hep::Vector3d rightPosition // position of the hit assuming it was on the right side of the wire, radially in the middle of the cell [mm]
       - float time                    // time of the hit [ns].
       - float eDep                    // energy deposited on the hit [GeV].
       - float eDepError               // error measured on eDep [GeV].

--- a/DCHdigi/dataFormatExtension/driftChamberHit.yaml
+++ b/DCHdigi/dataFormatExtension/driftChamberHit.yaml
@@ -10,12 +10,24 @@ options:
 datatypes:
 
   extension::DriftChamberDigi:
-    Description: "Drift chamber digitized hit (before tracking)"
+    Description: "Drift chamber digitized hit (before tracking) in local coordinates"
     Author: "B. Francois, CERN"
     Members:
       - uint64_t cellID               // ID of the wire that created this hit
       - float distanceToWire          // smeared distance of closest approach between the wire and the hit [mm]
       - float zPositionAlongWire      // smeared z position in the local wire coordinate system [mm]
+      - float time                    // time of the hit [ns].
+      - float eDep                    // energy deposited on the hit [GeV].
+      - float eDepError               // error measured on eDep [GeV].
+      - uint32_t clusterCount         // number of clusters associated to this hit
+
+  extension::DriftChamberDigiLeftRightGlobal:
+    Description: "Drift chamber digitized hit (before tracking) in local coordinates"
+    Author: "B. Francois, CERN"
+    Members:
+      - uint64_t cellID               // ID of the wire that created this hit
+      - edm4hep::Vector3d leftPosition // position of the hit assuming it was on the left side of the wire [mm]
+      - edm4hep::Vector3d rightPosition // position of the hit assuming it was on the right side of the wire [mm]
       - float time                    // time of the hit [ns].
       - float eDep                    // energy deposited on the hit [GeV].
       - float eDepError               // error measured on eDep [GeV].

--- a/DCHdigi/include/DCHsimpleDigitizer.h
+++ b/DCHdigi/include/DCHsimpleDigitizer.h
@@ -12,7 +12,15 @@
 
 // EDM4HEP
 #include "edm4hep/SimTrackerHitCollection.h"
+#include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
 
 // DD4HEP
 #include "DD4hep/Detector.h"  // for dd4hep::VolumeManager
@@ -20,7 +28,7 @@
 
 /** @class DCHsimpleDigitizer
  *
- *  Algorithm for creating digitized drift chamber hits (still based on edm4hep::TrackerHit) from edm4hep::SimTrackerHit.
+ *  Algorithm for creating digitized drift chamber hits (still based on edm4hep::TrackerHit3D) from edm4hep::SimTrackerHit.
  *  You have to specify the expected resolution in z and in xy (distance to the wire). The smearing is applied in the wire reference frame.
  *  
  *  @author Brieuc Francois
@@ -49,7 +57,7 @@ private:
   // Input sim tracker hit collection name
   DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  DataHandle<edm4hep::TrackerHitCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};

--- a/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
+++ b/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
@@ -14,7 +14,7 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 
 // EDM4HEP extension
-#include "extension/DriftChamberDigiCollection.h"
+#include "extension/DriftChamberDigiLeftRightGlobalCollection.h"
 
 // DD4HEP
 #include "DD4hep/Detector.h"  // for dd4hep::VolumeManager
@@ -51,7 +51,7 @@ private:
   // Input sim tracker hit collection name
   DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<extension::DriftChamberDigiLeftRightGlobalCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};

--- a/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
+++ b/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
@@ -15,6 +15,7 @@
 
 // EDM4HEP extension
 #include "extension/DriftChamberDigiCollection.h"
+#include "extension/MCRecoDriftChamberDigiAssociationCollection.h"
 
 // DD4HEP
 #include "DD4hep/Detector.h"  // for dd4hep::VolumeManager
@@ -52,6 +53,8 @@ private:
   DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
   DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  // Output association between digitized and simulated hit collections
+  DataHandle<extension::MCRecoDriftChamberDigiAssociationCollection> m_output_sim_digi_association{"outputSimDigiAssociation", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};

--- a/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
+++ b/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
@@ -10,11 +10,13 @@
 #include "k4FWCore/DataHandle.h"
 #include "k4Interface/IGeoSvc.h"
 
-// EDM4HEP
+// EDM4HEP & PODIO
 #include "edm4hep/SimTrackerHitCollection.h"
+#include "podio/UserDataCollection.h"
 
 // EDM4HEP extension
 #include "extension/DriftChamberDigiCollection.h"
+#include "extension/DriftChamberDigiLocalCollection.h"
 #include "extension/MCRecoDriftChamberDigiAssociationCollection.h"
 
 // DD4HEP
@@ -55,6 +57,8 @@ private:
   DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
   // Output association between digitized and simulated hit collections
   DataHandle<extension::MCRecoDriftChamberDigiAssociationCollection> m_output_sim_digi_association{"outputSimDigiAssociation", Gaudi::DataHandle::Writer, this};
+  // Output digitized tracker hit in local coordinates collection name. Only filled in debug mode
+  DataHandle<extension::DriftChamberDigiLocalCollection> m_output_digi_local_hits{"outputDigiLocalHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};
@@ -70,6 +74,13 @@ private:
                                "Spatial resolution in the z direction (from reading out the wires at both sides) [mm]"};
   // xy resolution in mm
   FloatProperty m_xy_resolution{this, "xyResolution", 0.1, "Spatial resolution in the xy direction [mm]"};
+  // Flag to produce debugging distributions
+  Gaudi::Property<bool> m_debugMode{this, "debugMode", false, "Flag to produce debugging distributions"};
+  // Declaration of debugging distributions
+  DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaDistToWire{"leftHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
+  DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaLocalZ{"leftHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
+  DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaDistToWire{"rightHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
+  DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaLocalZ{"rightHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
 
   // Random Number Service
   IRndmGenSvc* m_randSvc;

--- a/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
+++ b/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
@@ -14,7 +14,7 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 
 // EDM4HEP extension
-#include "extension/DriftChamberDigiLeftRightGlobalCollection.h"
+#include "extension/DriftChamberDigiCollection.h"
 
 // DD4HEP
 #include "DD4hep/Detector.h"  // for dd4hep::VolumeManager
@@ -51,7 +51,7 @@ private:
   // Input sim tracker hit collection name
   DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  DataHandle<extension::DriftChamberDigiLeftRightGlobalCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};

--- a/DCHdigi/src/DCHsimpleDigitizer.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizer.cpp
@@ -51,7 +51,7 @@ StatusCode DCHsimpleDigitizer::execute() {
   debug() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;
 
   // Digitize the sim hits
-  edm4hep::TrackerHitCollection* output_digi_hits = m_output_digi_hits.createAndPut();
+  edm4hep::TrackerHit3DCollection* output_digi_hits = m_output_digi_hits.createAndPut();
   for (const auto& input_sim_hit : *input_sim_hits) {
     auto output_digi_hit = output_digi_hits->create();
     // smear the hit position: need to go in the wire local frame to smear in the direction aligned/perpendicular with the wire for z/distanceToWire, taking e.g. stereo angle into account

--- a/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
@@ -97,7 +97,7 @@ StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
                                                     simHitLocalPosition[2] / dd4hep::mm);
     // get the smeared distance to the wire (cylindrical coordinate as the smearing should be perpendicular to the wire)
     debug() << "Original distance to wire: " << simHitLocalPositionVector.rho() << " mm" << endmsg;
-    double smearedDistanceToWire = simHitLocalPositionVector.rho() + m_gauss_xy.shoot() * dd4hep::mm;
+    double smearedDistanceToWire = simHitLocalPositionVector.rho() + m_gauss_xy.shoot();
     while(smearedDistanceToWire < 0){
       debug() << "Negative smearedDistanceToWire (" << smearedDistanceToWire << ") shooting another random number" << endmsg;
       smearedDistanceToWire = simHitLocalPositionVector.rho() + m_gauss_xy.shoot();
@@ -129,8 +129,8 @@ StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
             << " in cm" << endmsg;
     // fill the output DriftChamberDigi (making sure we are back in mm)
     output_digi_hit.setCellID(cellID);
-    edm4hep::Vector3d leftHitGlobalPositionVector = edm4hep::Vector3d({leftHitGlobalPosition[0] / dd4hep::mm, leftHitGlobalPosition[1] / dd4hep::mm, leftHitGlobalPosition[2] / dd4hep::mm});
-    edm4hep::Vector3d rightHitGlobalPositionVector = edm4hep::Vector3d({rightHitGlobalPosition[0] / dd4hep::mm, rightHitGlobalPosition[1] / dd4hep::mm, rightHitGlobalPosition[2] / dd4hep::mm});
+    edm4hep::Vector3d leftHitGlobalPositionVector = edm4hep::Vector3d(leftHitGlobalPosition[0] / dd4hep::mm, leftHitGlobalPosition[1] / dd4hep::mm, leftHitGlobalPosition[2] / dd4hep::mm);
+    edm4hep::Vector3d rightHitGlobalPositionVector = edm4hep::Vector3d(rightHitGlobalPosition[0] / dd4hep::mm, rightHitGlobalPosition[1] / dd4hep::mm, rightHitGlobalPosition[2] / dd4hep::mm);
     output_digi_hit.setLeftPosition(leftHitGlobalPositionVector);
     output_digi_hit.setRightPosition(rightHitGlobalPositionVector);
     output_digi_hit.setTime(input_sim_hit.getTime()); // will apply smearing when we know more from R&D teams

--- a/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
@@ -92,6 +92,7 @@ StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
     debug() << "Smeared distance to wire: " << smearedDistanceToWire << endmsg;
     // smear the z position (in local coordinate the z axis is aligned with the wire i.e. it take the stereo angle into account);
     double smearedZ = simHitLocalPositionVector.z() + m_gauss_z.shoot() * dd4hep::mm;
+    // NB: here we assume the hit is radially in the middle of the cell
     double leftHitLocalPosition[3]  = {-1 * smearedDistanceToWire, 0, smearedZ};
     double rightHitLocalPosition[3]  = {smearedDistanceToWire, 0, smearedZ};
     double leftHitGlobalPosition[3]  = {0, 0, 0};

--- a/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
@@ -51,11 +51,20 @@ StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
   const edm4hep::SimTrackerHitCollection* input_sim_hits = m_input_sim_hits.get();
   debug() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;
 
+  // Prepare a collection for digitized hits in local coordinate (only filled in debug mode)
+  extension::DriftChamberDigiCollection* output_digi_hits = m_output_digi_hits.createAndPut();
+  extension::DriftChamberDigiLocalCollection* output_digi_local_hits = m_output_digi_local_hits.createAndPut();
+
   // Prepare a collection for the association between digitized and simulated hit, setting weights to 1
   extension::MCRecoDriftChamberDigiAssociationCollection* digi_sim_associations = m_output_sim_digi_association.createAndPut();
 
+  // Prepare collections for the debugging distributions
+  auto leftHitSimHitDeltaDistToWire = m_leftHitSimHitDeltaDistToWire.createAndPut();
+  auto leftHitSimHitDeltaLocalZ = m_leftHitSimHitDeltaLocalZ.createAndPut();
+  auto rightHitSimHitDeltaDistToWire = m_rightHitSimHitDeltaDistToWire.createAndPut();
+  auto rightHitSimHitDeltaLocalZ = m_rightHitSimHitDeltaLocalZ.createAndPut();
+
   // Digitize the sim hits
-  extension::DriftChamberDigiCollection* output_digi_hits = m_output_digi_hits.createAndPut();
   for (const auto& input_sim_hit : *input_sim_hits) {
     auto output_digi_hit = output_digi_hits->create();
     // smear the hit position: need to go in the wire local frame to smear in the direction aligned/perpendicular with the wire for z/distanceToWire, taking e.g. stereo angle into account
@@ -67,9 +76,9 @@ StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
         Form("superLayer_%ld_layer_%ld_phi_%ld_wire", m_decoder->get(cellID, "superLayer"),
              m_decoder->get(cellID, "layer"), m_decoder->get(cellID, "phi"));
     dd4hep::DetElement wireDetElement = cellDetElement.child(wireDetElementName);
-    // get the transformation matrix used to place the wire
+    // get the transformation matrix used to place the wire (DD4hep works with cm)
     const auto& wireTransformMatrix = wireDetElement.nominal().worldTransformation();
-    // Retrieve global position in mm and apply unit transformation (translation matrix is stored in cm)
+    // Retrieve global position in mm and transform it to cm because the DD4hep translation matrix is stored in cm
     double simHitGlobalPosition[3] = {input_sim_hit.getPosition().x * dd4hep::mm,
                                       input_sim_hit.getPosition().y * dd4hep::mm,
                                       input_sim_hit.getPosition().z * dd4hep::mm};
@@ -83,35 +92,71 @@ StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
             << " in cm" << endmsg;
     debug() << "Global simHit z " << simHitGlobalPosition[2] << " --> Local simHit z " << simHitLocalPosition[2]
             << " in cm" << endmsg;
-    // build a vector to easily apply smearing of distance to the wire
-    dd4hep::rec::Vector3D simHitLocalPositionVector(simHitLocalPosition[0], simHitLocalPosition[1],
-                                                    simHitLocalPosition[2]);
+    // build a vector to easily apply smearing of distance to the wire, going back to mm
+    dd4hep::rec::Vector3D simHitLocalPositionVector(simHitLocalPosition[0] / dd4hep::mm, simHitLocalPosition[1] / dd4hep::mm,
+                                                    simHitLocalPosition[2] / dd4hep::mm);
     // get the smeared distance to the wire (cylindrical coordinate as the smearing should be perpendicular to the wire)
-    debug() << "Original distance to wire: " << simHitLocalPositionVector.rho() << endmsg;
+    debug() << "Original distance to wire: " << simHitLocalPositionVector.rho() << " mm" << endmsg;
     double smearedDistanceToWire = simHitLocalPositionVector.rho() + m_gauss_xy.shoot() * dd4hep::mm;
     while(smearedDistanceToWire < 0){
       debug() << "Negative smearedDistanceToWire (" << smearedDistanceToWire << ") shooting another random number" << endmsg;
-      smearedDistanceToWire = simHitLocalPositionVector.rho() + m_gauss_xy.shoot() * dd4hep::mm;
+      smearedDistanceToWire = simHitLocalPositionVector.rho() + m_gauss_xy.shoot();
     }
-    debug() << "Smeared distance to wire: " << smearedDistanceToWire << endmsg;
+    debug() << "Smeared distance to wire: " << smearedDistanceToWire << " mm " << endmsg;
     // smear the z position (in local coordinate the z axis is aligned with the wire i.e. it take the stereo angle into account);
-    double smearedZ = simHitLocalPositionVector.z() + m_gauss_z.shoot() * dd4hep::mm;
+    double smearedZ = simHitLocalPositionVector.z() + m_gauss_z.shoot();
     // NB: here we assume the hit is radially in the middle of the cell
-    double leftHitLocalPosition[3]  = {-1 * smearedDistanceToWire, 0, smearedZ};
-    double rightHitLocalPosition[3]  = {smearedDistanceToWire, 0, smearedZ};
+    // create the left and right hit local position (in cm again because of the transform matrix)
+    double leftHitLocalPosition[3]  = {-1 * smearedDistanceToWire  * dd4hep::mm, 0, smearedZ * dd4hep::mm};
+    double rightHitLocalPosition[3]  = {smearedDistanceToWire * dd4hep::mm, 0, smearedZ * dd4hep::mm};
+    // transform the left and right hit local position in global coordinate (still cm here)
     double leftHitGlobalPosition[3]  = {0, 0, 0};
     double rightHitGlobalPosition[3]  = {0, 0, 0};
     wireTransformMatrix.LocalToMaster(leftHitLocalPosition, leftHitGlobalPosition);
     wireTransformMatrix.LocalToMaster(rightHitLocalPosition, rightHitGlobalPosition);
+    //std::cout << (leftHitGlobalPosition[2]==rightHitGlobalPosition[2]) <<  std::endl; // FIXME why are left and right global z coordinates the same?
+    debug() << "Global leftHit x " << leftHitGlobalPosition[0] << " --> Local leftHit x " << leftHitLocalPosition[0]
+            << " in cm" << endmsg;
+    debug() << "Global leftHit y " << leftHitGlobalPosition[1] << " --> Local leftHit y " << leftHitLocalPosition[1]
+            << " in cm" << endmsg;
+    debug() << "Global leftHit z " << leftHitGlobalPosition[2] << " --> Local leftHit z " << leftHitLocalPosition[2]
+            << " in cm" << endmsg;
+    debug() << "Global rightHit x " << rightHitGlobalPosition[0] << " --> Local rightHit x " << rightHitLocalPosition[0]
+            << " in cm" << endmsg;
+    debug() << "Global rightHit y " << rightHitGlobalPosition[1] << " --> Local rightHit y " << rightHitLocalPosition[1]
+            << " in cm" << endmsg;
+    debug() << "Global rightHit z " << rightHitGlobalPosition[2] << " --> Local rightHit z " << rightHitLocalPosition[2]
+            << " in cm" << endmsg;
     // fill the output DriftChamberDigi (making sure we are back in mm)
     output_digi_hit.setCellID(cellID);
-    output_digi_hit.setLeftPosition(edm4hep::Vector3d({leftHitGlobalPosition[0] / dd4hep::mm, leftHitGlobalPosition[1] / dd4hep::mm, leftHitGlobalPosition[2] / dd4hep::mm}));
-    output_digi_hit.setRightPosition(edm4hep::Vector3d({rightHitGlobalPosition[0] / dd4hep::mm, rightHitGlobalPosition[1] / dd4hep::mm, rightHitGlobalPosition[2] / dd4hep::mm}));
+    edm4hep::Vector3d leftHitGlobalPositionVector = edm4hep::Vector3d({leftHitGlobalPosition[0] / dd4hep::mm, leftHitGlobalPosition[1] / dd4hep::mm, leftHitGlobalPosition[2] / dd4hep::mm});
+    edm4hep::Vector3d rightHitGlobalPositionVector = edm4hep::Vector3d({rightHitGlobalPosition[0] / dd4hep::mm, rightHitGlobalPosition[1] / dd4hep::mm, rightHitGlobalPosition[2] / dd4hep::mm});
+    output_digi_hit.setLeftPosition(leftHitGlobalPositionVector);
+    output_digi_hit.setRightPosition(rightHitGlobalPositionVector);
+    output_digi_hit.setTime(input_sim_hit.getTime()); // will apply smearing when we know more from R&D teams
+    //output_digi_hit.setEDep(input_sim_hit.getEDep()); // will enable this when we know more from R&D teams
+
 
     // create the association between digitized and simulated hit
     auto digi_sim_association = digi_sim_associations->create();
     digi_sim_association.setDigi(output_digi_hit);
     digi_sim_association.setSim(input_sim_hit);
+
+    // if required, populate debugging distributions
+    if(m_debugMode) {
+      // Fill the local coordinate digi hit
+      auto output_digi_local_hit = output_digi_local_hits->create();
+      output_digi_local_hit.setCellID(cellID);
+      output_digi_local_hit.setDistanceToWire(smearedDistanceToWire);
+      output_digi_local_hit.setZPositionAlongWire(smearedZ);
+      // produce a vector instead of using directly smearedDistanceToWire or smearedZ for a more thorough testing
+      dd4hep::rec::Vector3D leftHitLocalPositionVector(leftHitLocalPosition[0] / dd4hep::mm, leftHitLocalPosition[1] / dd4hep::mm, leftHitLocalPosition[2] / dd4hep::mm);
+      dd4hep::rec::Vector3D rightHitLocalPositionVector(rightHitLocalPosition[0] / dd4hep::mm, rightHitLocalPosition[1] / dd4hep::mm, rightHitLocalPosition[2] / dd4hep::mm);
+      leftHitSimHitDeltaDistToWire->push_back(leftHitLocalPositionVector.rho() - simHitLocalPositionVector.rho());
+      leftHitSimHitDeltaLocalZ->push_back(leftHitLocalPositionVector.z() - simHitLocalPositionVector.z());
+      rightHitSimHitDeltaDistToWire->push_back(rightHitLocalPositionVector.rho() - simHitLocalPositionVector.rho());
+      rightHitSimHitDeltaLocalZ->push_back(rightHitLocalPositionVector.z() - simHitLocalPositionVector.z());
+    }
   }
   debug() << "Output Digi Hit collection size: " << output_digi_hits->size() << endmsg;
   return StatusCode::SUCCESS;

--- a/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
@@ -51,7 +51,7 @@ StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
   debug() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;
 
   // Digitize the sim hits
-  extension::DriftChamberDigiLeftRightGlobalCollection* output_digi_hits = m_output_digi_hits.createAndPut();
+  extension::DriftChamberDigiCollection* output_digi_hits = m_output_digi_hits.createAndPut();
   for (const auto& input_sim_hit : *input_sim_hits) {
     auto output_digi_hit = output_digi_hits->create();
     // smear the hit position: need to go in the wire local frame to smear in the direction aligned/perpendicular with the wire for z/distanceToWire, taking e.g. stereo angle into account

--- a/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
+++ b/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
@@ -7,7 +7,7 @@ podioevent  = FCCDataSvc("EventDataSvc")
 
 from GaudiKernel.SystemOfUnits import MeV, GeV, tesla
 ################## Particle gun setup
-momentum = 5 # in GeV
+momentum = 10 # in GeV
 #thetaMin = 90.25 # degrees
 #thetaMax = 90.25 # degrees
 thetaMin = 20 # degrees
@@ -60,7 +60,7 @@ regiontool = SimG4UserLimitRegion("limits")
 regiontool.volumeNames = ["CDCH"]
 regiontool.OutputLevel = DEBUG
 from GaudiKernel.SystemOfUnits import mm
-regiontool.maxStep = 0.4*mm
+#regiontool.maxStep = 0.4*mm
 
 from Configurables import SimG4UserLimitPhysicsList
 # create overlay on top of FTFP_BERT physics list, attaching fast sim/parametrization process
@@ -135,7 +135,7 @@ out = PodioOutput("out",
 out.outputCommands = ["keep *"]
 
 import uuid
-out.filename = "output_simplifiedDriftChamber_MagneticField_"+str(magneticField)+"_pMin_"+str(momentum*1000)+"_MeV"+"_ThetaMinMax_"+str(thetaMin)+"_"+str(thetaMax)+"_pdgId_"+str(pdgCode)+"_stepLength_"+str(regiontool.maxStep)+".root"
+out.filename = "output_simplifiedDriftChamber_MagneticField_"+str(magneticField)+"_pMin_"+str(momentum*1000)+"_MeV"+"_ThetaMinMax_"+str(thetaMin)+"_"+str(thetaMax)+"_pdgId_"+str(pdgCode)+"_stepLength_default.root"
 
 #CPU information
 from Configurables import AuditorSvc, ChronoAuditor
@@ -162,7 +162,7 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax   = 10,
+    EvtMax   = 1000,
     ExtSvc = [geoservice, podioevent, geantservice, audsvc],
     StopOnSignal = True,
  )

--- a/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
+++ b/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
@@ -126,7 +126,8 @@ dch_digitizer = DCHsimpleDigitizerExtendedEdm("DCHsimpleDigitizerExtendedEdm",
     readoutName = "CDCHHits",
     xyResolution = 0.1, # mm
     zResolution = 1, # mm
-    OutputLevel=INFO
+    debugMode = False,
+    OutputLevel = INFO
 )
 
 # Derive performance quantities
@@ -144,6 +145,9 @@ from Configurables import PodioOutput
 out = PodioOutput("out",
                   OutputLevel=INFO)
 out.outputCommands = ["keep *"]
+if not dch_digitizer.debugMode:
+    out.outputCommands.append("drop *HitSimHitDelta*")
+    out.outputCommands.append("drop outputDigiLocalHits")
 
 import uuid
 out.filename = "output_simplifiedDriftChamber_MagneticField_"+str(magneticField)+"_pMin_"+str(momentum*1000)+"_MeV"+"_ThetaMinMax_"+str(thetaMin)+"_"+str(thetaMax)+"_pdgId_"+str(pdgCode)+"_stepLength_default.root"

--- a/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
+++ b/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
@@ -122,11 +122,22 @@ from Configurables import DCHsimpleDigitizerExtendedEdm
 dch_digitizer = DCHsimpleDigitizerExtendedEdm("DCHsimpleDigitizerExtendedEdm",
     inputSimHits = savetrackertool.SimTrackHits.Path,
     outputDigiHits = savetrackertool.SimTrackHits.Path.replace("sim", "digi"),
+    outputSimDigiAssociation = "DC_simDigiAssociation",
     readoutName = "CDCHHits",
     xyResolution = 0.1, # mm
     zResolution = 1, # mm
     OutputLevel=INFO
 )
+
+# Derive performance quantities
+#from Configurables import DCHsimpleDigitizerExtendedEdmPerformance
+#dch_perf = DCHsimpleDigitizerExtendedEdmPerformance("DCHsimpleDigitizerExtendedEdmPerformance",
+#        inputSimHits = savetrackertool.SimTrackHits.Path,
+#        inputDigiHits = dch_digitizer.outputDigiHits,
+#        inputSimDigiAssociation = dch_digitizer.outputSimDigiAssociation
+#)
+
+
 
 ################ Output
 from Configurables import PodioOutput
@@ -159,10 +170,11 @@ ApplicationMgr(
               hepmc_converter,
               geantsim,
               dch_digitizer,
+              #dch_perf,
               out
               ],
     EvtSel = 'NONE',
-    EvtMax   = 1000,
+    EvtMax   = 100,
     ExtSvc = [geoservice, podioevent, geantservice, audsvc],
     StopOnSignal = True,
  )

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ make install -j 8
 cd ../../
 export FCCDETECTORS=$PWD/FCCDetectors/;PATH=$PWD/FCCDetectors/install/bin/:$PATH;CMAKE_PREFIX_PATH=$PWD/FCCDetectors/install/:$CMAKE_PREFIX_PATH;LD_LIBRARY_PATH=$PWD/FCCDetectors/install/lib:$LD_LIBRARY_PATH;export PYTHONPATH=$PWD/FCCDetectors/install/python:$PYTHONPATH;LD_LIBRARY_PATH=$PWD/FCCDetectors/install/lib64:$LD_LIBRARY_PATH
 
-git clone git@github.com:BrieucF/k4RecTracker.git
+git clone git@github.com:key4hep/k4RecTracker.git
 cd k4RecTracker
 mkdir build install
 cd build
@@ -46,7 +46,7 @@ export K4RECTRACKER=$PWD/k4RecTracker/install/share/k4RecTracker; PATH=$PWD/k4Re
 Cloning:
 
 ```bash
-git clone git@github.com:BrieucF/k4RecTracker.git
+git clone git@github.com:key4hep/k4RecTracker.git
 ```
 
 Installing:

--- a/Tracking/include/GenFitter.h
+++ b/Tracking/include/GenFitter.h
@@ -9,7 +9,14 @@
 
 // EDM4HEP
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
 
 // GENFIT
 //#include "WireMeasurement.h"
@@ -42,7 +49,7 @@ public:
 
 private:
   // Input tracker hit collection name
-  DataHandle<edm4hep::TrackerHitCollection> m_input_hits{"inputHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> m_input_hits{"inputHits", Gaudi::DataHandle::Reader, this};
   // Output track collection name
   DataHandle<edm4hep::TrackCollection> m_output_tracks{"outputTracks", Gaudi::DataHandle::Writer, this};
   // Transient genfit measurements used internally by genfit to run the tracking

--- a/Tracking/src/GenFitter.cpp
+++ b/Tracking/src/GenFitter.cpp
@@ -13,7 +13,7 @@ StatusCode GenFitter::initialize() { return StatusCode::SUCCESS; }
 
 StatusCode GenFitter::execute() {
   // Get the input collection with tracker hits
-  const edm4hep::TrackerHitCollection* input_hits = m_input_hits.get();
+  const edm4hep::TrackerHit3DCollection* input_hits = m_input_hits.get();
   verbose() << "Input Hit collection size: " << input_hits->size() << endmsg;
 
   // Convert edm4hep::TrackerHitCollection to Genfit measurements

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -12,7 +12,15 @@
 
 // EDM4HEP
 #include "edm4hep/SimTrackerHitCollection.h"
+#include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
 
 // DD4HEP
 #include "DD4hep/Detector.h"  // for dd4hep::VolumeManager
@@ -23,7 +31,7 @@
 
 /** @class VTXdigitizer
  *
- *  Algorithm for creating digitized (meaning 'reconstructed' for now) vertex detector hits (edm4hep::TrackerHit) from Geant4 hits (edm4hep::SimTrackerHit).
+ *  Algorithm for creating digitized (meaning 'reconstructed' for now) vertex detector hits (edm4hep::TrackerHit3D) from Geant4 hits (edm4hep::SimTrackerHit).
  *  
  *  @author Brieuc Francois
  *  @date   2023-03
@@ -51,7 +59,7 @@ private:
   // Input sim vertex hit collection name
   DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized vertex hit collection name
-  DataHandle<edm4hep::TrackerHitCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
   // Detector name
   Gaudi::Property<std::string> m_detectorName{this, "detectorName", "Vertex", "Name of the detector (default: Vertex)"};

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -52,7 +52,7 @@ StatusCode VTXdigitizer::execute() {
   unsigned nDismissedHits=0;
 
   // Digitize the sim hits
-  edm4hep::TrackerHitCollection* output_digi_hits = m_output_digi_hits.createAndPut();
+  edm4hep::TrackerHit3DCollection* output_digi_hits = m_output_digi_hits.createAndPut();
   for (const auto& input_sim_hit : *input_sim_hits) {
     auto output_digi_hit = output_digi_hits->create();
 

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,3 +1,8 @@
+# v00-02-00
+
+* 2024-02-12 tmadlener ([PR#16](https://github.com/key4hep/k4RecTracker/pull/16))
+  - Add a schema_version to the data model extension to keep it working after [podio#556](https://github.com/AIDASoft/podio/pull/556)
+
 # v00-01
 
 * This file is also automatically populated by the tagging script


### PR DESCRIPTION
BEGINRELEASENOTES
- Drift chamber digitized hit are now in global coordinate by default
- Add a debug mode in the drift chamber digitizer which produces additional distributions and a digi collection in local coordinates 

ENDRELEASENOTES
