### PR TITLE
Add missing GaudiAlgLib

### DIFF
--- a/ARCdigi/CMakeLists.txt
+++ b/ARCdigi/CMakeLists.txt
@@ -14,6 +14,7 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore

--- a/DCHdigi/CMakeLists.txt
+++ b/DCHdigi/CMakeLists.txt
@@ -45,6 +45,7 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   extensionDict

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -17,6 +17,7 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore

--- a/VTXdigi/CMakeLists.txt
+++ b/VTXdigi/CMakeLists.txt
@@ -13,6 +13,7 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore


### PR DESCRIPTION
BEGINRELEASENOTES
- Add missing GaudiAlgLib, which seems to be giving some problems now in the nightlies

ENDRELEASENOTES

```
     195    ERROR: failed to load libTracking.so: /tmp/root/spack-stage/spack-s
            tage-k4rectracker-b57a973dfc1fed965e1f1ff3c887d3213ccd6060_develop-
            f7ngqb45c67dqhzkagooeqpmjfetss2m/spack-build-f7ngqb4/Tracking/libTr
            acking.so: undefined symbol: _ZTI14GaudiAlgorithm
```

GaudiAlg is deprecated but this will allow to unblock the nightlies, that they don't build. I'm not sure what has changed for this to be an issue now, it's also happening in another package that do not link to GaudiAlgLib.