### PR TITLE
Remove setting dE/dx to track since it will be removed in EDM4hep

### DIFF
--- a/Tracking/src/GenFitter.cpp
+++ b/Tracking/src/GenFitter.cpp
@@ -26,7 +26,6 @@ StatusCode GenFitter::execute() {
   auto                      output_track  = output_tracks->create();
   output_track.setChi2(1.);
   output_track.setNdf(1);
-  output_track.setDEdx(1.);
   return StatusCode::SUCCESS;
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove setting a dummy dE/dx value, since the edm4hep::Track will no longer have it after [EDM4hep#311](https://github.com/key4hep/EDM4hep/pull/311)

ENDRELEASENOTES
