### PR TITLE
Do not use GaudiAlg

### DIFF
--- a/ARCdigi/CMakeLists.txt
+++ b/ARCdigi/CMakeLists.txt
@@ -14,7 +14,6 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
-  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore

--- a/ARCdigi/include/ARCdigitizer.h
+++ b/ARCdigi/include/ARCdigitizer.h
@@ -44,7 +44,7 @@ public:
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  virtual StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */

--- a/ARCdigi/include/ARCdigitizer.h
+++ b/ARCdigi/include/ARCdigitizer.h
@@ -2,7 +2,7 @@
 
 // GAUDI
 #include "Gaudi/Property.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/IRndmGenSvc.h"
 #include "GaudiKernel/RndmGenerators.h"
 
@@ -33,7 +33,7 @@ namespace edm4hep {
  *
  */
 
-class ARCdigitizer : public GaudiAlgorithm {
+class ARCdigitizer : public Gaudi::Algorithm {
 public:
   explicit ARCdigitizer(const std::string&, ISvcLocator*);
   virtual ~ARCdigitizer();
@@ -52,9 +52,9 @@ public:
 
 private:
   // Input sim tracker hit collection name
-  DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
   // Flat value for SiPM efficiency
   FloatProperty m_flat_SiPM_effi{this, "flatSiPMEfficiency", -1.0, "Flat value for SiPM quantum efficiency (<0 := disabled)"};
   // Apply the SiPM efficiency to digitized hits instead of simulated hits

--- a/ARCdigi/src/ARCdigitizer.cpp
+++ b/ARCdigi/src/ARCdigitizer.cpp
@@ -12,7 +12,7 @@
 
 DECLARE_COMPONENT(ARCdigitizer)
 
-ARCdigitizer::ARCdigitizer(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc) {
+ARCdigitizer::ARCdigitizer(const std::string& aName, ISvcLocator* aSvcLoc) : Gaudi::Algorithm(aName, aSvcLoc) {
   declareProperty("inputSimHits", m_input_sim_hits, "Input sim tracker hit collection name");
   declareProperty("outputDigiHits", m_output_digi_hits, "Output digitized tracker hit collection name");
 }

--- a/ARCdigi/src/ARCdigitizer.cpp
+++ b/ARCdigi/src/ARCdigitizer.cpp
@@ -43,7 +43,7 @@ StatusCode ARCdigitizer::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode ARCdigitizer::execute() {
+StatusCode ARCdigitizer::execute(const EventContext&) const {
   // Get the input collection with Geant4 hits
   const edm4hep::SimTrackerHitCollection* input_sim_hits = m_input_sim_hits.get();
   verbose() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;

--- a/DCHdigi/CMakeLists.txt
+++ b/DCHdigi/CMakeLists.txt
@@ -45,7 +45,6 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
-  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   extensionDict

--- a/DCHdigi/include/DCHsimpleDigitizer.h
+++ b/DCHdigi/include/DCHsimpleDigitizer.h
@@ -47,7 +47,7 @@ public:
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  virtual StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */

--- a/DCHdigi/include/DCHsimpleDigitizer.h
+++ b/DCHdigi/include/DCHsimpleDigitizer.h
@@ -2,7 +2,7 @@
 
 // GAUDI
 #include "Gaudi/Property.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/IRndmGenSvc.h"
 #include "GaudiKernel/RndmGenerators.h"
 
@@ -36,7 +36,7 @@ namespace edm4hep {
  *
  */
 
-class DCHsimpleDigitizer : public GaudiAlgorithm {
+class DCHsimpleDigitizer : public Gaudi::Algorithm {
 public:
   explicit DCHsimpleDigitizer(const std::string&, ISvcLocator*);
   virtual ~DCHsimpleDigitizer();
@@ -55,9 +55,9 @@ public:
 
 private:
   // Input sim tracker hit collection name
-  DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};

--- a/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
+++ b/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
@@ -44,7 +44,7 @@ public:
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  virtual StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */

--- a/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
+++ b/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
@@ -2,7 +2,7 @@
 
 // GAUDI
 #include "Gaudi/Property.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/IRndmGenSvc.h"
 #include "GaudiKernel/RndmGenerators.h"
 
@@ -33,7 +33,7 @@
  *
  */
 
-class DCHsimpleDigitizerExtendedEdm : public GaudiAlgorithm {
+class DCHsimpleDigitizerExtendedEdm : public Gaudi::Algorithm {
 public:
   explicit DCHsimpleDigitizerExtendedEdm(const std::string&, ISvcLocator*);
   virtual ~DCHsimpleDigitizerExtendedEdm();
@@ -52,13 +52,13 @@ public:
 
 private:
   // Input sim tracker hit collection name
-  DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
   // Output association between digitized and simulated hit collections
-  DataHandle<extension::MCRecoDriftChamberDigiAssociationCollection> m_output_sim_digi_association{"outputSimDigiAssociation", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<extension::MCRecoDriftChamberDigiAssociationCollection> m_output_sim_digi_association{"outputSimDigiAssociation", Gaudi::DataHandle::Writer, this};
   // Output digitized tracker hit in local coordinates collection name. Only filled in debug mode
-  DataHandle<extension::DriftChamberDigiLocalCollection> m_output_digi_local_hits{"outputDigiLocalHits", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<extension::DriftChamberDigiLocalCollection> m_output_digi_local_hits{"outputDigiLocalHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};
@@ -77,10 +77,10 @@ private:
   // Flag to produce debugging distributions
   Gaudi::Property<bool> m_debugMode{this, "debugMode", false, "Flag to produce debugging distributions"};
   // Declaration of debugging distributions
-  DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaDistToWire{"leftHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
-  DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaLocalZ{"leftHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
-  DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaDistToWire{"rightHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
-  DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaLocalZ{"rightHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
+  mutable DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaDistToWire{"leftHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
+  mutable DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaLocalZ{"leftHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
+  mutable DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaDistToWire{"rightHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
+  mutable DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaLocalZ{"rightHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
 
   // Random Number Service
   IRndmGenSvc* m_randSvc;

--- a/DCHdigi/src/DCHsimpleDigitizer.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizer.cpp
@@ -10,7 +10,7 @@
 DECLARE_COMPONENT(DCHsimpleDigitizer)
 
 DCHsimpleDigitizer::DCHsimpleDigitizer(const std::string& aName, ISvcLocator* aSvcLoc)
-    : GaudiAlgorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "DCHsimpleDigitizer") {
+    : Gaudi::Algorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "DCHsimpleDigitizer") {
   declareProperty("inputSimHits", m_input_sim_hits, "Input sim tracker hit collection name");
   declareProperty("outputDigiHits", m_output_digi_hits, "Output digitized tracker hit collection name");
 }

--- a/DCHdigi/src/DCHsimpleDigitizer.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizer.cpp
@@ -45,7 +45,7 @@ StatusCode DCHsimpleDigitizer::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode DCHsimpleDigitizer::execute() {
+StatusCode DCHsimpleDigitizer::execute(const EventContext&) const {
   // Get the input collection with Geant4 hits
   const edm4hep::SimTrackerHitCollection* input_sim_hits = m_input_sim_hits.get();
   debug() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;

--- a/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
@@ -46,7 +46,7 @@ StatusCode DCHsimpleDigitizerExtendedEdm::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode DCHsimpleDigitizerExtendedEdm::execute() {
+StatusCode DCHsimpleDigitizerExtendedEdm::execute(const EventContext&) const {
   // Get the input collection with Geant4 hits
   const edm4hep::SimTrackerHitCollection* input_sim_hits = m_input_sim_hits.get();
   debug() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;

--- a/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
+++ b/DCHdigi/src/DCHsimpleDigitizerExtendedEdm.cpp
@@ -10,7 +10,7 @@
 DECLARE_COMPONENT(DCHsimpleDigitizerExtendedEdm)
 
 DCHsimpleDigitizerExtendedEdm::DCHsimpleDigitizerExtendedEdm(const std::string& aName, ISvcLocator* aSvcLoc)
-    : GaudiAlgorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "DCHsimpleDigitizerExtendedEdm") {
+    : Gaudi::Algorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "DCHsimpleDigitizerExtendedEdm") {
   declareProperty("inputSimHits", m_input_sim_hits, "Input sim tracker hit collection name");
   declareProperty("outputDigiHits", m_output_digi_hits, "Output digitized tracker hit collection name");
   declareProperty("outputSimDigiAssociation", m_output_sim_digi_association, "Output name for the association between digitized and simulated hit collections");

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -17,7 +17,6 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
-  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore

--- a/Tracking/include/GenFitter.h
+++ b/Tracking/include/GenFitter.h
@@ -2,7 +2,7 @@
 
 // GAUDI
 #include "Gaudi/Property.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 
 // K4FWCORE
 #include "k4FWCore/DataHandle.h"
@@ -30,7 +30,7 @@ namespace edm4hep {
  *
  */
 
-class GenFitter : public GaudiAlgorithm {
+class GenFitter : public Gaudi::Algorithm {
 public:
   explicit GenFitter(const std::string&, ISvcLocator*);
   virtual ~GenFitter();
@@ -49,9 +49,9 @@ public:
 
 private:
   // Input tracker hit collection name
-  DataHandle<edm4hep::TrackerHit3DCollection> m_input_hits{"inputHits", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_input_hits{"inputHits", Gaudi::DataHandle::Reader, this};
   // Output track collection name
-  DataHandle<edm4hep::TrackCollection> m_output_tracks{"outputTracks", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::TrackCollection> m_output_tracks{"outputTracks", Gaudi::DataHandle::Writer, this};
   // Transient genfit measurements used internally by genfit to run the tracking
   //std::vector<genfit::WireMeasurement> m_wire_measurements;
 };

--- a/Tracking/include/GenFitter.h
+++ b/Tracking/include/GenFitter.h
@@ -41,7 +41,7 @@ public:
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  virtual StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */

--- a/Tracking/src/GenFitter.cpp
+++ b/Tracking/src/GenFitter.cpp
@@ -11,7 +11,7 @@ GenFitter::~GenFitter() {}
 
 StatusCode GenFitter::initialize() { return StatusCode::SUCCESS; }
 
-StatusCode GenFitter::execute() {
+StatusCode GenFitter::execute(const EventContext&) const {
   // Get the input collection with tracker hits
   const edm4hep::TrackerHit3DCollection* input_hits = m_input_hits.get();
   verbose() << "Input Hit collection size: " << input_hits->size() << endmsg;

--- a/Tracking/src/GenFitter.cpp
+++ b/Tracking/src/GenFitter.cpp
@@ -2,7 +2,7 @@
 
 DECLARE_COMPONENT(GenFitter)
 
-GenFitter::GenFitter(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc) {
+GenFitter::GenFitter(const std::string& aName, ISvcLocator* aSvcLoc) : Gaudi::Algorithm(aName, aSvcLoc) {
   declareProperty("inputHits", m_input_hits, "Input tracker hit collection name");
   declareProperty("outputTracks", m_output_tracks, "Output track collection name");
 }

--- a/VTXdigi/CMakeLists.txt
+++ b/VTXdigi/CMakeLists.txt
@@ -13,7 +13,6 @@ file(GLOB headers
 gaudi_add_module(${PackageName}
   SOURCES ${sources}
   LINK
-  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -82,7 +82,7 @@ private:
   FloatProperty m_t_resolution{this, "tResolution", 0.1, "Time resolution [ns]"};
 
   // Surface manager used to project hits onto sensitive surface with forceHitsOntoSurface argument
-  const dd4hep::rec::SurfaceMap* _map;
+  mutable const dd4hep::rec::SurfaceMap* _map;
 
   // Option to force hits onto sensitive surface
   BooleanProperty m_forceHitsOntoSurface{this, "forceHitsOntoSurface", false, "Project hits onto the surface in case they are not yet on the surface (default: false"};

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -2,7 +2,7 @@
 
 // GAUDI
 #include "Gaudi/Property.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/IRndmGenSvc.h"
 #include "GaudiKernel/RndmGenerators.h"
 
@@ -38,7 +38,7 @@ namespace edm4hep {
  *
  */
 
-class VTXdigitizer : public GaudiAlgorithm {
+class VTXdigitizer : public Gaudi::Algorithm {
 public:
   explicit VTXdigitizer(const std::string&, ISvcLocator*);
   virtual ~VTXdigitizer();
@@ -57,9 +57,9 @@ public:
 
 private:
   // Input sim vertex hit collection name
-  DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized vertex hit collection name
-  DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
   // Detector name
   Gaudi::Property<std::string> m_detectorName{this, "detectorName", "Vertex", "Name of the detector (default: Vertex)"};

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -49,7 +49,7 @@ public:
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  virtual StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -44,7 +44,7 @@ StatusCode VTXdigitizer::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode VTXdigitizer::execute() {
+StatusCode VTXdigitizer::execute(const EventContext&) const {
   // Get the input collection with Geant4 hits
   const edm4hep::SimTrackerHitCollection* input_sim_hits = m_input_sim_hits.get();
   verbose() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -3,7 +3,7 @@
 DECLARE_COMPONENT(VTXdigitizer)
 
 VTXdigitizer::VTXdigitizer(const std::string& aName, ISvcLocator* aSvcLoc)
-    : GaudiAlgorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "VTXdigitizer") {
+    : Gaudi::Algorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "VTXdigitizer") {
   declareProperty("inputSimHits", m_input_sim_hits, "Input sim vertex hit collection name");
   declareProperty("outputDigiHits", m_output_digi_hits, "Output digitized vertex hit collection name");
 }


### PR DESCRIPTION
These are the changes needed not to use GaudiAlg, which will be removed (maybe soon) in Gaudi.

BEGINRELEASENOTES
- Change headers and add EventContext in algorithms not to use GaudiAlg
- Replace `GaudiTool` with `AlgTool`

ENDRELEASENOTES