### PR TITLE
Minor fixes: add missing k4FWCore::k4Interface when linking and fix warning about an unused variable

### DIFF
--- a/DCHdigi/CMakeLists.txt
+++ b/DCHdigi/CMakeLists.txt
@@ -50,6 +50,7 @@ gaudi_add_module(${PackageName}
   EDM4HEP::edm4hep
   extensionDict
   k4FWCore::k4FWCore
+  k4FWCore::k4Interface
   DD4hep::DDRec
 )
 

--- a/VTXdigi/CMakeLists.txt
+++ b/VTXdigi/CMakeLists.txt
@@ -17,6 +17,7 @@ gaudi_add_module(${PackageName}
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore
+  k4FWCore::k4Interface
   DD4hep::DDRec
 )
 

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -49,8 +49,6 @@ StatusCode VTXdigitizer::execute() {
   const edm4hep::SimTrackerHitCollection* input_sim_hits = m_input_sim_hits.get();
   verbose() << "Input Sim Hit collection size: " << input_sim_hits->size() << endmsg;
 
-  unsigned nDismissedHits=0;
-
   // Digitize the sim hits
   edm4hep::TrackerHit3DCollection* output_digi_hits = m_output_digi_hits.createAndPut();
   for (const auto& input_sim_hit : *input_sim_hits) {
@@ -105,8 +103,6 @@ StatusCode VTXdigitizer::execute() {
             
           simHitGlobalPositionVector = oldPosOnSurf ;
         } 
-        else
-          ++nDismissedHits;
       }
     }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add missing k4FWCore::k4Interface when linking, it's needed (although it works fine in the stack) because some files from k4Interface are being included
- Fix warning about an unused variable

ENDRELEASENOTES