### PR TITLE
Make sure MarlinUtil is found

### DIFF
--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -3,7 +3,7 @@ set(PackageName Tracking)
 project(${PackageName})
 
 #find_package(GenFit)
-FIND_PACKAGE(MarlinUtil)
+find_package(MarlinUtil REQUIRED)
 
 #if (GenFit_FOUND)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add REQUIRED for MarlinUtil in CMakeLists.txt

ENDRELEASENOTES

After #21, if it's not found compilation will fail so let's add it here.