### PR TITLE
Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(ROOT COMPONENTS RIO Tree MathCore)
 find_package(EDM4HEP)
 find_package(k4FWCore)
 find_package(Gaudi)
-find_package(MarlinUtil REQUIRED)
 #---------------------------------------------------------------
 
 include(cmake/Key4hepConfig.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,36 +21,11 @@ find_package(ROOT COMPONENTS RIO Tree MathCore)
 find_package(EDM4HEP)
 find_package(k4FWCore)
 find_package(Gaudi)
+find_package(MarlinUtil REQUIRED)
 #---------------------------------------------------------------
 
+include(cmake/Key4hepConfig.cmake)
 include(GNUInstallDirs)
-
-# Set up C++ Standard
-# ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-
-if(NOT CMAKE_CXX_STANDARD MATCHES "14|17|20")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-
-# use, i.e. don't skip the full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-
-# when building, don't use the install RPATH already
-# (but later on when installing)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
-# add the automatically determined parts of the RPATH
-# which point to directories outside the build tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-# the RPATH to be used when installing, but only if it's not a system directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-if("${isSystemDir}" STREQUAL "-1")
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-endif("${isSystemDir}" STREQUAL "-1")
 
 include(CTest)
 function(set_test_env _testname)


### PR DESCRIPTION
See https://github.com/key4hep/EDM4hep/pull/359.

BEGINRELEASENOTES
- Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.

ENDRELEASENOTES