### PR TITLE
Remove the check for TrackerHit3D from edm4hep

### DIFF
--- a/ARCdigi/include/ARCdigitizer.h
+++ b/ARCdigi/include/ARCdigitizer.h
@@ -11,14 +11,7 @@
 
 // EDM4HEP
 #include "edm4hep/SimTrackerHitCollection.h"
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-}  // namespace edm4hep
-#endif
 
 // DD4HEP
 #include "DD4hep/Detector.h"

--- a/DCHdigi/include/DCHsimpleDigitizer.h
+++ b/DCHdigi/include/DCHsimpleDigitizer.h
@@ -12,14 +12,7 @@
 
 // EDM4HEP
 #include "edm4hep/SimTrackerHitCollection.h"
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-}  // namespace edm4hep
-#endif
 
 // DD4HEP
 #include "DD4hep/Detector.h"  // for dd4hep::VolumeManager

--- a/Tracking/include/GenFitter.h
+++ b/Tracking/include/GenFitter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 // GAUDI
-#include "Gaudi/Property.h"
 #include "Gaudi/Algorithm.h"
 
 // K4FWCORE
@@ -9,14 +8,7 @@
 
 // EDM4HEP
 #include "edm4hep/TrackCollection.h"
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-}  // namespace edm4hep
-#endif
 
 // GENFIT
 //#include "WireMeasurement.h"

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -12,15 +12,7 @@
 
 // EDM4HEP
 #include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/TrackCollection.h"
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-}  // namespace edm4hep
-#endif
 #include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
 
 // DD4HEP


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the check for TrackerHit3D from edm4hep

ENDRELEASENOTES

See https://github.com/key4hep/k4FWCore/pull/265