### PR TITLE
Add senseWireHit as in edm4hep PR

### DIFF
--- a/DCHdigi/dataFormatExtension/driftChamberHit.yaml
+++ b/DCHdigi/dataFormatExtension/driftChamberHit.yaml
@@ -143,6 +143,41 @@ datatypes:
 
 # end of "the following is just because interface looks for e.g. extension/TrackerHit3DCollection.h"
 
+# new version of digitized drift chamber digi, resulting from https://github.com/key4hep/EDM4hep/pull/385 discussion
+# defined here for validation before to merge in central edm4hep
+  extension::SenseWireHit:
+    Description: "Sense wire hit, before the hit position degeneracy is resolved. The circle representing possible positions is parametrized with its center, radius and normal vector (given by the wire direction)."
+    Author: "EDM4hep authors"
+    Members:
+      - uint64_t cellID // ID of the sensor that created this hit
+      - int32_t type // type of the raw data hit
+      - int32_t quality // quality bit flag of the hit
+      - float time [ns] // time of the hit
+      - float eDep [GeV] // energy deposited by the hit
+      - float eDepError [GeV] // error on eDep
+      - float wireStereoAngle // angle between the sense wire axis and the drift chamber axis (usually the z-axis) - use it together with wireAzimuthalAngle to get the wire direction
+      - float wireAzimuthalAngle // azimuthal angle at the middle of the sense wire - use it together with wireStereoAngle to get the wire direction
+      - edm4hep::Vector3d position [mm] // point on the sense wire which is closest to the hit (center of the circle)
+      - double positionAlongWireError [mm] // error on the hit position along the wire direction
+      - float distanceToWire [mm] // distance between the hit and the wire (radius of the circle)
+      - float distanceToWireError [mm] // error on distanceToWire
+    VectorMembers:
+      - uint16_t nElectrons // number of electrons for each cluster (number of clusters = vector size)
+    ExtraCode:
+      declaration: "
+        /// Return the number of clusters associated to the hit\n
+        auto getNClusters() const { return getNElectrons().size(); }\n
+        "
+
+  extension::SenseWireHitSimTrackerHitLink:
+    Description: "Link between a SenseWireHit and a SimTrackerHit"
+    Author: "EDM4hep authors"
+    Members:
+      - float weight                      // weight of this link
+    OneToOneRelations:
+     - extension::SenseWireHit from     // reference to the SenseWireHit
+     - edm4hep::SimTrackerHit to          // reference to the SimTrackerHit
+
 interfaces:
   extension::TrackerHit:
     Description: "Tracker hit interface class"
@@ -159,3 +194,19 @@ interfaces:
       - extension::TrackerHitPlane
       - extension::TrackerHit3D
       - extension::DriftChamberDigiV2
+
+  extension::TrackerHit_dev:
+    Description: "Tracker hit interface class to test the mixing of extension and edm4hep data types"
+    Author: "Thomas Madlener, DESY"
+    Members:
+      - uint64_t cellID // ID of the sensor that created this hit
+      - int32_t type // type of the raw data hit
+      - int32_t quality // quality bit flag of the hit
+      - float time [ns] // time of the hit
+      - float eDep [GeV] // energy deposited on the hit
+      - float eDepError [GeV] // error measured on eDep
+      - edm4hep::Vector3d position [mm] // hit position
+    Types:
+      - edm4hep::TrackerHitPlane
+      - edm4hep::TrackerHit3D
+      - extension::SenseWireHit


### PR DESCRIPTION
BEGINRELEASENOTES
- Add SenseWireHit data type in extension to validate the content of https://github.com/key4hep/EDM4hep/pull/385

ENDRELEASENOTES

As discussed at the edm4hep meeting this morning, I open this PR to allow @atolosadelgado to propagate it to the digitizer. This will then enable to test this data type in the ML based track finding and make sure it is suitable before merging.