### PR TITLE
Set test dependencies for tracking tests that need a simulated file

### DIFF
--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -59,9 +59,11 @@ install(FILES ${scripts} DESTINATION test)
 SET(test_name "test_TracksFromGenParticles")
 ADD_TEST(NAME ${test_name} COMMAND k4run test/runTracksFromGenParticles.py)
 set_test_env(${test_name})
+set_tests_properties(${test_name} PROPERTIES DEPENDS "test_runDCHdigiV2")
 
 SET(test_name "test_TracksFromGenParticlesAlg")
 ADD_TEST(NAME ${test_name} COMMAND k4run test/runTracksFromGenParticlesAlg.py)
 set_test_env(${test_name})
+set_tests_properties(${test_name} PROPERTIES DEPENDS "test_runDCHdigiV2")
 
 #endif()


### PR DESCRIPTION
BEGINRELEASENOTES
- Set test dependencies for tracking tests that need a simulated file

ENDRELEASENOTES

This should help with the failures in CI, that currently may or may not fail depending if these two tests run before the one that generates their input file or not.