### PR TITLE
Move rdn distributions inside call operator

### DIFF
--- a/DCHdigi/include/DCHdigi_v01.h
+++ b/DCHdigi/include/DCHdigi_v01.h
@@ -127,12 +127,6 @@ private:
   inline static thread_local std::mt19937_64 m_engine;
   void                                       PrepareRandomEngine(const edm4hep::EventHeaderCollection& headers) const;
 
-  // Operator std::normal_distribution<T>::operator()(Generator& g) is a non-const member function and thus cannot be called for a constant object. So we defined the distribution as mutable.
-  // Gaussian random number generator used for the smearing of the z position, in cm!
-  mutable std::normal_distribution<double> m_gauss_z_cm;
-  // Gaussian random number generator used for the smearing of the xy position, in cm!
-  mutable std::normal_distribution<double> m_gauss_xy_cm;
-
   /// members with internal state (such as random engines) must be defined thread local
   inline static thread_local TRandom3 myRandom;
   //------------------------------------------------------------------

--- a/DCHdigi/src/DCHdigi_v01.cpp
+++ b/DCHdigi/src/DCHdigi_v01.cpp
@@ -31,11 +31,9 @@ StatusCode DCHdigi_v01::initialize() {
 
   if( 0 > m_z_resolution.value() )
     ThrowException("Z resolution input value can not be negative!");
-  m_gauss_z_cm  = std::normal_distribution<double>(0., m_z_resolution.value() * MM_TO_CM);
 
   if( 0 > m_xy_resolution.value() )
     ThrowException("Radial (XY) resolution input value can not be negative!");
-  m_gauss_xy_cm = std::normal_distribution<double>(0., m_xy_resolution.value() * MM_TO_CM);
 
   //-----------------
   // Retrieve the subdetector
@@ -101,6 +99,10 @@ DCHdigi_v01::operator()(const edm4hep::SimTrackerHitCollection& input_sim_hits,
                     const edm4hep::EventHeaderCollection&   headers) const {
   // initialize seed for random engine
   this->PrepareRandomEngine(headers);
+  // Gaussian random number generator used for the smearing of the z position, in cm!
+  std::normal_distribution<double> m_gauss_z_cm{0., m_z_resolution.value() * MM_TO_CM};
+  // Gaussian random number generator used for the smearing of the xy position, in cm!
+  std::normal_distribution<double> m_gauss_xy_cm{0., m_xy_resolution.value() * MM_TO_CM};
 
   debug() << "Input Sim Hit collection size: " << input_sim_hits.size() << endmsg;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Limit scope of random distributions inside the call operator to prevent race conditions

ENDRELEASENOTES

The following random distributions have an internal state, and therefore making them just mutable is not enough to prevent a race condition. Thanks @m-fila for noticing!

```
Standard random distributions in `<random>` that **store an internal state**:

1. **`std::normal_distribution`**  
   - Uses the **Box-Muller transform** (or Ziggurat method, implementation-dependent) to generate normally distributed numbers.
   - Box-Muller requires generating two uniform random numbers to compute two normal variates at once. Since only one may be returned per call, the second is stored for the next invocation.

2. **`std::lognormal_distribution`**  
   - Based on `std::normal_distribution`, so it inherits the same internal state.

3. **`std::chi_squared_distribution`**  
   - Often implemented using a sum of squared normal-distributed numbers, which may use an internal state.

4. **`std::cauchy_distribution`**  
   - Sometimes uses an internal state to handle extreme values in its heavy-tailed distribution.

5. **`std::gamma_distribution`**  
   - Uses an internal state for more complex number generation algorithms like the Marsaglia-Tsang method.

6. **`std::weibull_distribution`**  
   - May cache intermediate calculations for efficiency.

7. **`std::extreme_value_distribution`**  
   - Sometimes uses an internal state for transformations.

The key reason these distributions maintain state is that they involve **transforms or algorithms that produce multiple values at a time** but can only return one per function call. The remaining value(s) need to be stored for subsequent calls to maintain efficiency.
```