### PR TITLE
Use the properties `Input` and `Output` with `IOSvc`

### DIFF
--- a/DCHdigi/test/test_DCHdigi/runDCHdigi.py
+++ b/DCHdigi/test/test_DCHdigi/runDCHdigi.py
@@ -9,8 +9,8 @@ from Configurables import EventDataSvc, UniqueIDGenSvc
 from k4FWCore import ApplicationMgr, IOSvc
 
 svc = IOSvc("IOSvc")
-svc.input = [ "dch_proton_10GeV.root"]
-svc.output = "dch_proton_10GeV_digi.root"
+svc.Input = [ "dch_proton_10GeV.root"]
+svc.Output = "dch_proton_10GeV_digi.root"
 
 from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc")

--- a/Tracking/test/runTracksFromGenParticles.py
+++ b/Tracking/test/runTracksFromGenParticles.py
@@ -8,8 +8,8 @@ if not os.path.isfile("ddsim_output_edm4hep.root"):
 # Loading the output of the SIM step
 from k4FWCore import IOSvc
 io_svc = IOSvc("IOSvc")
-io_svc.input = "ddsim_output_edm4hep.root"
-io_svc.output = "tracks_from_genParticle_output.root"
+io_svc.Input = "ddsim_output_edm4hep.root"
+io_svc.Output = "tracks_from_genParticle_output.root"
 
 # Calling TracksFromGenParticles
 from Configurables import TracksFromGenParticles


### PR DESCRIPTION
because `input` and `output` have been deprecated for a while. There is a message in the logs when running a steering file saying that they are deprecated but maybe no one noticed.

BEGINRELEASENOTES
- Use the properties `Input` and `Output` with `IOSvc` instead of the deprecated `input` and `output`

ENDRELEASENOTES