### PR TITLE
Move DataHandle and MetaDataHandle to the k4FWCore namespace

### DIFF
--- a/ARCdigi/include/ARCdigitizer.h
+++ b/ARCdigi/include/ARCdigitizer.h
@@ -45,11 +45,11 @@ public:
 
 private:
   // Input sim tracker hit collection name
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader,
-                                                                        this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits",
+                                                                                  Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer,
-                                                                         this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
   // Flat value for SiPM efficiency
   FloatProperty m_flat_SiPM_effi{this, "flatSiPMEfficiency", -1.0,
                                  "Flat value for SiPM quantum efficiency (<0 := disabled)"};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ dd4hep_set_compiler_flags()
 find_package(ROOT COMPONENTS RIO Tree MathCore)
 find_package(podio 1.2 REQUIRED)
 find_package(EDM4HEP)
-find_package(k4FWCore)
+find_package(k4FWCore 1.3 REQUIRED)
 find_package(Gaudi)
 find_package(GSL)
 #---------------------------------------------------------------

--- a/DCHdigi/include/DCHdigi_v01.h
+++ b/DCHdigi/include/DCHdigi_v01.h
@@ -165,7 +165,8 @@ private:
   AlgData* flData;
 
   /// code developed by Walaa for calculating number of clusters and cluster size of each one
-  std::pair<uint32_t, std::vector<int>> CalculateClusters(const edm4hep::SimTrackerHit& input_sim_hit, TRandom3 & myRandom) const;
+  std::pair<uint32_t, std::vector<int>> CalculateClusters(const edm4hep::SimTrackerHit& input_sim_hit,
+                                                          TRandom3& myRandom) const;
 
   bool IsParticleCreatedInsideDriftChamber(const edm4hep::MCParticle&) const;
 

--- a/DCHdigi/include/DCHsimpleDigitizer.h
+++ b/DCHdigi/include/DCHsimpleDigitizer.h
@@ -48,11 +48,11 @@ public:
 
 private:
   // Input sim tracker hit collection name
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader,
-                                                                        this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits",
+                                                                                  Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer,
-                                                                         this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "CDCHHits", "Name of the detector readout"};

--- a/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
+++ b/DCHdigi/include/DCHsimpleDigitizerExtendedEdm.h
@@ -53,16 +53,16 @@ public:
 
 private:
   // Input sim tracker hit collection name
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader,
-                                                                        this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits",
+                                                                                  Gaudi::DataHandle::Reader, this};
   // Output digitized tracker hit collection name
-  mutable DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{"outputDigiHits",
-                                                                               Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<extension::DriftChamberDigiCollection> m_output_digi_hits{
+      "outputDigiHits", Gaudi::DataHandle::Writer, this};
   // Output association between digitized and simulated hit collections
-  mutable DataHandle<extension::MCRecoDriftChamberDigiAssociationCollection> m_output_sim_digi_association{
+  mutable k4FWCore::DataHandle<extension::MCRecoDriftChamberDigiAssociationCollection> m_output_sim_digi_association{
       "outputSimDigiAssociation", Gaudi::DataHandle::Writer, this};
   // Output digitized tracker hit in local coordinates collection name. Only filled in debug mode
-  mutable DataHandle<extension::DriftChamberDigiLocalCollection> m_output_digi_local_hits{
+  mutable k4FWCore::DataHandle<extension::DriftChamberDigiLocalCollection> m_output_digi_local_hits{
       "outputDigiLocalHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout name
@@ -82,13 +82,13 @@ private:
   // Flag to produce debugging distributions
   Gaudi::Property<bool> m_debugMode{this, "debugMode", false, "Flag to produce debugging distributions"};
   // Declaration of debugging distributions
-  mutable DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaDistToWire{
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaDistToWire{
       "leftHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
-  mutable DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaLocalZ{
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_leftHitSimHitDeltaLocalZ{
       "leftHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
-  mutable DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaDistToWire{
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaDistToWire{
       "rightHitSimHitDeltaDistToWire", Gaudi::DataHandle::Writer, this}; // mm
-  mutable DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaLocalZ{
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_rightHitSimHitDeltaLocalZ{
       "rightHitSimHitDeltaLocalZ", Gaudi::DataHandle::Writer, this}; // mm
 
   // Random Number Service

--- a/Tracking/include/GenFitter.h
+++ b/Tracking/include/GenFitter.h
@@ -41,9 +41,11 @@ public:
 
 private:
   // Input tracker hit collection name
-  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_input_hits{"inputHits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> m_input_hits{"inputHits", Gaudi::DataHandle::Reader,
+                                                                             this};
   // Output track collection name
-  mutable DataHandle<edm4hep::TrackCollection> m_output_tracks{"outputTracks", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackCollection> m_output_tracks{"outputTracks", Gaudi::DataHandle::Writer,
+                                                                         this};
   // Transient genfit measurements used internally by genfit to run the tracking
   // std::vector<genfit::WireMeasurement> m_wire_measurements;
 };

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -53,13 +53,13 @@ public:
 
 private:
   // Input sim vertex hit collection name
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader,
-                                                                        this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits",
+                                                                                  Gaudi::DataHandle::Reader, this};
   // Output digitized vertex hit collection name
-  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer,
-                                                                         this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> m_output_digi_hits{"outputDigiHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
   // Output link between sim hits and digitized hits
-  mutable DataHandle<edm4hep::TrackerHitSimTrackerHitLinkCollection> m_output_sim_digi_link{
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHitSimTrackerHitLinkCollection> m_output_sim_digi_link{
       "outputSimDigiAssociation", Gaudi::DataHandle::Writer, this};
 
   // Detector name


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DataHandle and MetaDataHandle to the k4FWCore namespace, done in k4FWCore in https://github.com/key4hep/k4FWCore/pull/317
- Bump the required version of k4FWCore

ENDRELEASENOTES