### PR TITLE
remove compatibility with older Gaudi versions

### DIFF
--- a/Tracking/components/PlotTrackHitResiduals.cpp
+++ b/Tracking/components/PlotTrackHitResiduals.cpp
@@ -18,16 +18,6 @@
 // k4FWCore
 #include "k4FWCore/Consumer.h"
 
-#include "GAUDI_VERSION.h"
-
-#if GAUDI_MAJOR_VERSION < 39
-namespace Gaudi::Accumulators {
-template <unsigned int ND, atomicity Atomicity = atomicity::full, typename Arithmetic = double>
-using StaticHistogram = Gaudi::Accumulators::HistogramingCounterBase<ND, Atomicity, Arithmetic, naming::histogramString,
-                                                                     HistogramingAccumulator>;
-}
-#endif
-
 #include <string>
 
 /** @class PlotTrackHitDistances


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove histogram interface compatibility with Gaudi versions older that v39

ENDRELEASENOTES

Both the nigthlies and the current release (2026-02-01) have Gaudi  newer than 39.

See https://github.com/key4hep/k4FWCore/pull/378