### PR TITLE
Fix phi0 type in PCAInfo, correct omega sign, and add covariance matrix to TrackStates

### DIFF
--- a/Tracking/components/GenfitTrackFitter.cpp
+++ b/Tracking/components/GenfitTrackFitter.cpp
@@ -657,7 +657,7 @@ private:
                                      m_filterTrackHits);
 
     if (!isFit) {
-      debug() << "Track fit FAILED for track " << num_tracks - 1 << endmsg;
+      info() << "Track fit FAILED for track " << num_tracks - 1 << endmsg;
       return false;
     }
 

--- a/Tracking/components/GenfitTrackFitter.cpp
+++ b/Tracking/components/GenfitTrackFitter.cpp
@@ -508,7 +508,7 @@ private:
 
   Gaudi::Property<double> m_sigma_d0{
       this, "Sigma_d0", 0.05,
-      "Initial uncertainty on d0 (mm) for the initial covariance matrix when InitializationType = 0,1,3."};
+      "Initial uncertainty on d0 (cm) for the initial covariance matrix when InitializationType = 0,1,3."};
   Gaudi::Property<double> m_sigma_phi{
       this, "Sigma_phi", 0.1,
       "Initial uncertainty on phi (rad) for the initial covariance matrix when InitializationType = 0,1,3."};
@@ -519,7 +519,7 @@ private:
   Gaudi::Property<double> m_z0_factor{
       this, "Z0Factor", 0.1,
       "Scaling factor for z0 uncertainty for the initial covariance matrix when InitializationType = 0,1,3."
-      "The actual sigma_z0 is computed as Z0Factor * |z0|"};
+      "The actual sigma_z0 is computed as Z0Factor * |z0 (in cm)|"};
   Gaudi::Property<double> m_sigma_tanLambda{
       this, "Sigma_tanLambda", 0.1,
       "Initial uncertainty on tanLambda for the initial covariance matrix when InitializationType = 0,1,3."};

--- a/Tracking/components/GenfitTrackFitter.cpp
+++ b/Tracking/components/GenfitTrackFitter.cpp
@@ -508,7 +508,7 @@ private:
 
   Gaudi::Property<double> m_sigma_d0{
       this, "Sigma_d0", 0.05,
-      "Initial uncertainty on d0 (cm) for the initial covariance matrix when InitializationType = 0,1,3."};
+      "Initial uncertainty on d0 (mm) for the initial covariance matrix when InitializationType = 0,1,3."};
   Gaudi::Property<double> m_sigma_phi{
       this, "Sigma_phi", 0.1,
       "Initial uncertainty on phi (rad) for the initial covariance matrix when InitializationType = 0,1,3."};
@@ -529,10 +529,10 @@ private:
                                             "Defines where the reference point and helix parameters are taken from"};
 
   Gaudi::Property<std::vector<double>> m_init_position{
-      this, "InitPosition", {0., 0., 0.}, "User-defined initial position for InitializationType = 3"};
+      this, "InitPosition", {0., 0., 0.}, "User-defined initial position [in mm] for InitializationType = 3"};
 
   Gaudi::Property<std::vector<double>> m_init_momentum{
-      this, "InitMomentum", {0., 0., 0.}, "User-defined initial momentum for InitializationType = 3"};
+      this, "InitMomentum", {0., 0., 0.}, "User-defined initial momentum [in GeV/c] for InitializationType = 3"};
 
   Gaudi::Property<double> m_epsilon{
       this, "Epsilon", 1e-4,
@@ -619,14 +619,16 @@ private:
     GenfitInterface::GenfitTrack track_interface(track, m_skipTrackOrdering, m_dch_info, m_dc_decoder,
                                                  m_genfitField.get());
 
-    TVector3 Init_position(m_init_position.value()[0], m_init_position.value()[1], m_init_position.value()[2]);
+    TVector3 Init_position(m_init_position.value()[0] * dd4hep::mm, m_init_position.value()[1] * dd4hep::mm,
+                           m_init_position.value()[2] * dd4hep::mm);
 
     TVector3 Init_momentum(m_init_momentum.value()[0], m_init_momentum.value()[1], m_init_momentum.value()[2]);
 
     track_interface.InitializeTrack(m_RadialThresholdPromptTrack.value(), m_useFirstHitAsReference, LimitHits,
                                     m_initializationType, m_trackStateLocation.value(), Init_position, Init_momentum,
-                                    m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value(), m_sigma_phi.value(),
-                                    m_omega_factor.value(), m_z0_factor.value(), m_sigma_tanLambda.value());
+                                    m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value() * dd4hep::mm,
+                                    m_sigma_phi.value(), m_omega_factor.value(), m_z0_factor.value(),
+                                    m_sigma_tanLambda.value());
 
     auto track_init = track_interface.GetInitialization();
 
@@ -776,7 +778,7 @@ private:
 
       track_interface.InitializeTrack(m_RadialThresholdPromptTrack.value(), m_useFirstHitAsReference, LimitHits,
                                       m_initializationType, m_trackStateLocation.value(), Init_position, Init_momentum,
-                                      m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value(),
+                                      m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value() * dd4hep::mm,
                                       m_sigma_phi.value(), m_omega_factor.value(), m_z0_factor.value(),
                                       m_sigma_tanLambda.value());
 

--- a/Tracking/components/GenfitTrackFitter.cpp
+++ b/Tracking/components/GenfitTrackFitter.cpp
@@ -368,8 +368,14 @@ struct GenfitTrackFitter final
             debug() << "Track " << num_tracks - 1 << ": fit failed for single evaluation hypothesis, skipping track."
                     << endmsg;
             auto failedTrack = FittedTracks.create();
+            auto failedFittedTrack = FittedTracksWithFilteredHits.create();
+
             failedTrack.setChi2(-1);
             failedTrack.setNdf(-1);
+
+            failedFittedTrack.setChi2(-1);
+            failedFittedTrack.setNdf(-1);
+
             continue;
           }
 
@@ -382,8 +388,13 @@ struct GenfitTrackFitter final
             debug() << "Track " << num_tracks - 1 << ": fit failed for all hypotheses." << endmsg;
             number_failures += 1;
             auto failedTrack = FittedTracks.create();
+            auto failedFittedTrack = FittedTracksWithFilteredHits.create();
+
             failedTrack.setChi2(-1);
             failedTrack.setNdf(-1);
+
+            failedFittedTrack.setChi2(-1);
+            failedFittedTrack.setNdf(-1);
             continue;
 
           } else {
@@ -715,8 +726,8 @@ private:
         }
       }
 
-      FittedTracksWithFilteredHits.push_back(edm4hep_track_with_fit);
       FittedHits = std::move(track_interface.GetFittedHits());
+      FittedTracksWithFilteredHits.push_back(edm4hep_track_with_fit);
     }
 
     return true;

--- a/Tracking/components/GenfitTrackFitter.cpp
+++ b/Tracking/components/GenfitTrackFitter.cpp
@@ -657,7 +657,7 @@ private:
                                      m_filterTrackHits);
 
     if (!isFit) {
-      info() << "Track fit FAILED for track " << num_tracks - 1 << endmsg;
+      debug() << "Track fit FAILED for track " << num_tracks - 1 << endmsg;
       return false;
     }
 

--- a/Tracking/include/genfit_interfaces/GenfitTrack.h
+++ b/Tracking/include/genfit_interfaces/GenfitTrack.h
@@ -116,9 +116,9 @@ public:
   }
 
   struct HelperInitialization {
-    TVector3 Position;
-    TVector3 Momentum;
-    TMatrixDSym CovMatrix;
+    TVector3 Position;     // in cm
+    TVector3 Momentum;     // in GeV/c
+    TMatrixDSym CovMatrix; // in cm and GeV units
     int Charge;
     int NumHits;
   };

--- a/Tracking/include/genfit_interfaces/GenfitTrack.h
+++ b/Tracking/include/genfit_interfaces/GenfitTrack.h
@@ -134,7 +134,7 @@ private:
 
   struct PCAInfoHelper {
     TVector3 PCA;
-    int Phi0;
+    double Phi0;
   };
 
   void CheckInitialization();

--- a/Tracking/include/genfit_interfaces/GenfitTrack.h
+++ b/Tracking/include/genfit_interfaces/GenfitTrack.h
@@ -144,6 +144,9 @@ private:
   TMatrixDSym CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_helix, TVector3 Position_cm, TVector3 Momentum_gev,
                                                TVector3 RefPoint_cm, double Bz);
 
+  TMatrixDSym CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6
+                                               TVector3 Momentum_gev, double Bz);
+
   TMatrixDSym ComputeInitialCovarianceMatrix(double Bz, std::optional<double> sigma_d0, std::optional<double> sigma_phi,
                                              std::optional<double> sigma_omega, std::optional<double> sigma_z0,
                                              std::optional<double> sigma_tanLambda);

--- a/Tracking/include/genfit_interfaces/GenfitTrack.h
+++ b/Tracking/include/genfit_interfaces/GenfitTrack.h
@@ -142,14 +142,15 @@ private:
   void LimitNumberHits(double epsilon, int smoothWindow);
 
   TMatrixDSym CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_helix, TVector3 Position_cm, TVector3 Momentum_gev,
-                                               TVector3 RefPoint_cm, double Bz);
+                                               TVector3 RefPoint_cm, int charge, double Bz);
 
-  TMatrixDSym CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6
-                                               TVector3 Momentum_gev, double Bz);
+  TMatrixDSym CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6,
+                                               TVector3 Position_cm, TVector3 Momentum_gev, TVector3 RefPoint_cm,
+                                               int Charge, double Bz);
 
-  TMatrixDSym ComputeInitialCovarianceMatrix(double Bz, std::optional<double> sigma_d0, std::optional<double> sigma_phi,
-                                             std::optional<double> sigma_omega, std::optional<double> sigma_z0,
-                                             std::optional<double> sigma_tanLambda);
+  TMatrixDSym ComputeInitialCovarianceMatrix(double Bz, int Charge, std::optional<double> sigma_d0,
+                                             std::optional<double> sigma_phi, std::optional<double> sigma_omega,
+                                             std::optional<double> sigma_z0, std::optional<double> sigma_tanLambda);
 
   HelperInitialization ComputeInitialParameters(double Bz);
 

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -1333,20 +1333,12 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
 
   // omega = q * a * Bz / pt, with pt = sqrt(px^2 + py^2)
   double pt2 = px * px + py * py;
-
-  // domega / dx_PCA, domega / dy_PCA, domega / dz_PCA
-  J(2, 0) = 0.0; // domega / dx_PCA
-  J(2, 1) = 0.0; // domega / dy_PCA
-  J(2, 2) = 0.0; // domega / dz_PCA
-
-  // domega / dpx
+  J(2, 0) = 0.0;               // domega / dx_PCA
+  J(2, 1) = 0.0;               // domega / dy_PCA
+  J(2, 2) = 0.0;               // domega / dz_PCA
   J(2, 3) = -omega * px / pt2; // domega / dpx
-
-  // domega / dpy
   J(2, 4) = -omega * py / pt2; // domega / dpy
-
-  // domega / dpz
-  J(2, 5) = 0.0; // domega / dpz = 0
+  J(2, 5) = 0.0;               // domega / dpz
 
   // z0 = P^0_z - P^r_z
   J(3, 0) = 0.0; // dz0 / dx_PCA

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -713,7 +713,7 @@ GenfitTrack::HelperInitialization GenfitTrack::ComputeInitialParameters(double B
   const double rx = center.X() - pos.X();
   const double ry = center.Y() - pos.Y();
 
-  const int sign = (init_mom.X() * ry - init_mom.Y() * rx > 0) ? 1 : -1;
+  const int sign = (init_mom.X() * ry - init_mom.Y() * rx > 0) ? -1 : 1;
 
   const int bzSign = (Bz > 0) ? 1 : -1;
   int charge = sign * bzSign;
@@ -1272,13 +1272,6 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
   TMatrixDSym covariancePosMom(6);
 
   MeasuredState.getPosMomCov(gen_position, gen_momentum, covariancePosMom);
-
-  if (location == edm4hep::TrackState::AtIP) {
-
-    gen_momentum.SetX(-gen_momentum.X());
-    gen_momentum.SetY(-gen_momentum.Y());
-    gen_momentum.SetZ(-gen_momentum.Z());
-  }
 
   double x_ref = gen_position.X(); // cm
   double y_ref = gen_position.Y(); // cm

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -280,8 +280,8 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
     HelperInitialization initInfo = ComputeInitialParameters(Bz);
     m_charge_hypothesis = initInfo.Charge;
 
-    m_covInit = ComputeInitialCovarianceMatrix(Bz, sigma_d0.value(), sigma_phi.value(), omega_factor.value(),
-                                               z0_factor.value(), sigma_tanLambda.value());
+    m_covInit = ComputeInitialCovarianceMatrix(Bz, m_charge_hypothesis, sigma_d0.value(), sigma_phi.value(),
+                                               omega_factor.value(), z0_factor.value(), sigma_tanLambda.value());
   }
 
   else if (InitializationType == 1) // --- Refined
@@ -311,8 +311,8 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
     m_posInit = initInfo.Position;
     m_momInit = initInfo.Momentum;
 
-    m_covInit = ComputeInitialCovarianceMatrix(Bz, sigma_d0.value(), sigma_phi.value(), omega_factor.value(),
-                                               z0_factor.value(), sigma_tanLambda.value());
+    m_covInit = ComputeInitialCovarianceMatrix(Bz, m_charge_hypothesis, sigma_d0.value(), sigma_phi.value(),
+                                               omega_factor.value(), z0_factor.value(), sigma_tanLambda.value());
   }
 
   else if (InitializationType == 2) // --- From TrackState
@@ -364,7 +364,8 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
         }
 
         // Convert to Cartesian covariance
-        m_covInit = CovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint, Bz);
+        m_covInit = CovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint,
+                                                     m_charge_hypothesis, Bz);
       }
     }
 
@@ -388,8 +389,8 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
     HelperInitialization initInfo = ComputeInitialParameters(Bz);
     m_charge_hypothesis = initInfo.Charge;
 
-    m_covInit = ComputeInitialCovarianceMatrix(Bz, sigma_d0.value(), sigma_phi.value(), omega_factor.value(),
-                                               z0_factor.value(), sigma_tanLambda.value());
+    m_covInit = ComputeInitialCovarianceMatrix(Bz, m_charge_hypothesis, sigma_d0.value(), sigma_phi.value(),
+                                               omega_factor.value(), z0_factor.value(), sigma_tanLambda.value());
   }
 
   else {
@@ -547,6 +548,7 @@ void GenfitTrack::LimitNumberHits(double epsilon, int smoothWindow) {
  * - Returns the covariance matrix in Cartesian state representation.
  *
  * @param Bz Magnetic field component along the z axis.
+ * @param Charge Particle charge hypothesis (+1 or -1).
  * @param sigma_d0 Optional uncertainty on d0 (default 0.05).
  * @param sigma_phi Optional uncertainty on phi (default 0.1).
  * @param omega_factor Scaling factor for curvature uncertainty (default 0.5).
@@ -555,7 +557,7 @@ void GenfitTrack::LimitNumberHits(double epsilon, int smoothWindow) {
  *
  * @return Covariance matrix in Cartesian coordinates (6x6).
  */
-TMatrixDSym GenfitTrack::ComputeInitialCovarianceMatrix(double Bz, std::optional<double> sigma_d0,
+TMatrixDSym GenfitTrack::ComputeInitialCovarianceMatrix(double Bz, int Charge, std::optional<double> sigma_d0,
                                                         std::optional<double> sigma_phi,
                                                         std::optional<double> omega_factor,
                                                         std::optional<double> z0_factor,
@@ -585,7 +587,8 @@ TMatrixDSym GenfitTrack::ComputeInitialCovarianceMatrix(double Bz, std::optional
   C_helix(4, 4) = stl * stl;
 
   // Convert to Cartesian covariance
-  TMatrixDSym covState = CovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint, Bz);
+  TMatrixDSym covState =
+      CovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint, Charge, Bz);
 
   return covState;
 }
@@ -1136,13 +1139,14 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
  * @param Position_cm    Inizial Position in cm
  * @param Momentum_gev   Initial Momentum in gev/c
  * @param RefPoint_cm    Reference position (e.g. IP)
+ * @param Charge         Charge hypothesis
  * @param Bz             Bz
  *
  * @return Covariance matrix in cartesian-basis
  */
 TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_helix, // 5x5
                                                           TVector3 Position_cm, TVector3 Momentum_gev,
-                                                          TVector3 RefPoint_cm, double Bz) {
+                                                          TVector3 RefPoint_cm, int Charge, double Bz) {
 
   double x_PCA = Position_cm.X();
   double y_PCA = Position_cm.Y();
@@ -1156,8 +1160,10 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
 
   double d0 = -(RefPoint_cm.X() - x_PCA) * sin(phi0) + (RefPoint_cm.Y() - y_PCA) * cos(phi0);
 
-  double tanLambda = pz / pt;
   double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)) * dd4hep::mm;
+
+  if (Bz * Charge < 0)
+    omega = -omega;
 
   // --- Jacobian (6x5) ---
   TMatrixD J(6, 5);
@@ -1166,19 +1172,40 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
   // These definitions are taken from
   // https://flc.desy.de/lcnotes/notes/localfsExplorer_read?currentPath=/afs/desy.de/group/flc/lcnotes/LC-DET-2006-004.pdf
 
-  // x = x_PCA = P^0_x = d0/sin(phi0) + P^r_x - (P^r_y - P^0_y) / tan(phi0)
-  J(0, 0) = 1.0 / sin(phi0);                                          // dx / dd0
-  J(0, 1) = ((RefPoint_cm.Y() - y_PCA) - d0 * cos(phi0)) / sin(phi0); // dx / dphi0
-  J(0, 2) = 0.0;                                                      // dx / domega
-  J(0, 3) = 0.0;                                                      // dx / dz0
-  J(0, 4) = 0.0;                                                      // dx / dtanLambda
+  // The transverse impact parameter d0 is defined as the projection of the
+  // displacement vector between the reference point Pr and the PCA P0
+  // onto the unit normal vector to the track direction at the PCA.
+  //
+  // d = P0 - Pr = (x_PCA - Xr, y_PCA - Yr)
+  //
+  // n_PCA = (-sin(phi0), cos(phi0))
+  //
+  // Therefore:
+  //
+  // d0 = n_PCA · d
+  //    = (x_PCA - Xr)(-sin(phi0))
+  //      + (y_PCA - Yr)(cos(phi0))
+  //
+  // Since the displacement vector from the reference point to the PCA is
+  // parallel to the normal direction:
+  //
+  // P0 - Pr = d0 * n_PCA
+  //
+  // the PCA coordinates become:
+  //
+  // x_PCA = Xr - d0 * sin(phi0)
+  // y_PCA = Yr + d0 * cos(phi0)
+  J(0, 0) = -sin(phi0);      // dx / dd0
+  J(0, 1) = -d0 * cos(phi0); // dx / dphi0
+  J(0, 2) = 0.0;             // dx / domega
+  J(0, 3) = 0.0;             // dx / dz0
+  J(0, 4) = 0.0;             // dx / dtanLambda
 
-  // y = y_PCA = P^0_y =  - d0/cos(phi0) + P^r_y + (P^r_x - P^0_x) * tan(phi0)
-  J(1, 0) = -1.0 / cos(phi0);                                         // dy / dd0
-  J(1, 1) = ((RefPoint_cm.X() - x_PCA) - d0 * sin(phi0)) / cos(phi0); // dy / dphi0
-  J(1, 2) = 0.0;                                                      // dy / domega
-  J(1, 3) = 0.0;                                                      // dy / dz0
-  J(1, 4) = 0.0;                                                      // dy / dtanLambda
+  J(1, 0) = cos(phi0);       // dy / dd0
+  J(1, 1) = -d0 * sin(phi0); // dy / dphi0
+  J(1, 2) = 0.0;             // dy / domega
+  J(1, 3) = 0.0;             // dy / dz0
+  J(1, 4) = 0.0;             // dy / dtanLambda
 
   // z = z_PCA = P^0_z = z0 + P^r_z
   J(2, 0) = 0.0; // dz / dd0
@@ -1187,30 +1214,26 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
   J(2, 3) = 1.0; // dz / dz0
   J(2, 4) = 0.0; // dz / dtanLambda
 
-  // px = pt * cos(phi0) = a * Bz / omega * cos(phi0) = p * cos(phi0) * sin(theta) = p * cos(phi0) *
-  // sin(cot^-1(tanLambda))
-  J(3, 0) = 0.0;                   // dpx / dd0
-  J(3, 1) = -px * std::tan(phi0);  // dpx / dphi0
-  J(3, 2) = -px / std::abs(omega); // dpx / domega
-  J(3, 3) = 0.0;                   // dpx / dz0
-  J(3, 4) =
-      -Momentum_gev.Mag() * std::cos(phi0) * tanLambda / std::pow(1.0 + tanLambda * tanLambda, 1.5); // dpx / dtanLambda
+  // px = pt * cos(phi0) = a * Bz / omega * cos(phi0)
+  J(3, 0) = 0.0;         // dpx / dd0
+  J(3, 1) = -py;         // dpx / dphi0
+  J(3, 2) = -px / omega; // dpx / domega
+  J(3, 3) = 0.0;         // dpx / dz0
+  J(3, 4) = 0.0;         // dpx / dtanLambda
 
-  // py = pt * sin(phi0) = a * Bz / omega * sin(phi0) = p * sin(phi0) * sin(theta) = p * sin(phi0) *
-  // sin(cot^-1(tanLambda))
-  J(4, 0) = 0.0;                   // dpy / dd0
-  J(4, 1) = -py / std::tan(phi0);  // dpy / dphi0
-  J(4, 2) = -py / std::abs(omega); // dpy / domega
-  J(4, 3) = 0.0;                   // dpy / dz0
-  J(4, 4) =
-      -Momentum_gev.Mag() * std::sin(phi0) * tanLambda / std::pow(1.0 + tanLambda * tanLambda, 1.5); // dpy / dtanLambda
+  // py = pt * sin(phi0) = a * Bz / omega * sin(phi0)
+  J(4, 0) = 0.0;         // dpy / dd0
+  J(4, 1) = px;          // dpy / dphi0
+  J(4, 2) = -py / omega; // dpy / domega
+  J(4, 3) = 0.0;         // dpy / dz0
+  J(4, 4) = 0.0;         // dpy / dtanLambda
 
   // pz = pt * tanLambda = a * Bz / omega * tanLambda = p * cos(theta) = p * cos(cot^-1(tanLambda))
-  J(5, 0) = 0.0;                   // dpz / dd0
-  J(5, 1) = 0.0;                   // dpz / dphi0
-  J(5, 2) = -pz / std::abs(omega); // dpz / domega
-  J(5, 3) = 0.0;                   // dpz / dz0
-  J(5, 4) = pt;                    // dpz / dtanLambda
+  J(5, 0) = 0.0;         // dpz / dd0
+  J(5, 1) = 0.0;         // dpz / dphi0
+  J(5, 2) = -pz / omega; // dpz / domega
+  J(5, 3) = 0.0;         // dpz / dz0
+  J(5, 4) = pt;          // dpz / dtanLambda
 
   // --- Compute C_cart = J * C_helix * J^T ---
   TMatrixD Jt(TMatrixD::kTransposed, J);
@@ -1237,23 +1260,33 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
  * representation
  *
  * @param C_cartesian    Covariance Matrix in cartesian-basis
+ * @param Position_cm    Inizial Position in cm
  * @param Momentum_gev   Initial Momentum in gev/c
+ * @param RefPoint_cm    Reference position (e.g. IP)
+ * @param Charge         Charge hypothesis
  * @param Bz             Bz
  *
  * @return Covariance matrix in helix-basis
  */
 TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6
-                                                          TVector3 Momentum_gev, double Bz) {
+                                                          TVector3 Position_cm, TVector3 Momentum_gev,
+                                                          TVector3 RefPoint_cm, int Charge, double Bz) {
 
   double px = Momentum_gev.X();
   double py = Momentum_gev.Y();
   double pz = Momentum_gev.Z();
+
+  double x_PCA = Position_cm.X();
+  double y_PCA = Position_cm.Y();
 
   double pt = Momentum_gev.Perp();
 
   double phi0 = std::atan2(py, px);
   double tanLambda = pz / pt;
   double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)) * dd4hep::mm;
+
+  if (Bz * Charge < 0)
+    omega = -omega;
 
   // --- Jacobian (5x6) ---
   TMatrixD J(5, 6);
@@ -1262,29 +1295,42 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
   // These definitions are taken from
   // https://flc.desy.de/lcnotes/notes/localfsExplorer_read?currentPath=/afs/desy.de/group/flc/lcnotes/LC-DET-2006-004.pdf
 
-  // d0 = -(RefPoint_cm.X() - x_PCA) * sin(phi0) + (RefPoint_cm.Y() - y_PCA) * cos(phi0);
-  J(0, 0) = sin(phi0); // dd0 / dx_PCA
-  J(0, 1) = cos(phi0); // dd0 / dy_PCA
-  J(0, 2) = 0.0;       // dd0 / dz_PCA
-  J(0, 3) = 0.0;       // dd0 / dpx
-  J(0, 4) = 0.0;       // dd0 / dpy
-  J(0, 5) = 0.0;       // dd0 / dpz
+  // d0 = -(Xr - x)*sin(phi0) + (Yr - y)*cos(phi0)
+  J(0, 0) = sin(phi0);  // dd0 / dx
+  J(0, 1) = -cos(phi0); // dd0 / dy
+  J(0, 2) = 0.0;        // dd0 / dz
+
+  // chain rule via phi0 = atan2(py, px)
+  double dd0_dphi = -(RefPoint_cm.X() - x_PCA) * cos(phi0) - (RefPoint_cm.Y() - y_PCA) * sin(phi0);
+
+  J(0, 3) = dd0_dphi * (-py / (pt * pt)); // dd0 / dpx
+  J(0, 4) = dd0_dphi * (px / (pt * pt));  // dd0 / dpy
+  J(0, 5) = 0.0;                          // dd0 / dpz
 
   // phi0 = atan2(py, px);
-  J(1, 0) = -py / std::pow(pt, 2); // dphi0 / dx_PCA
-  J(1, 1) = px / std::pow(pt, 2);  // dphi0 / dy_PCA
-  J(1, 2) = 0.0;                   // dphi0 / dz_PCA
-  J(1, 3) = 0.0;                   // dphi0 / dpx
-  J(1, 4) = 0.0;                   // dphi0 / dpy
+  J(1, 0) = 0.0;                   // dphi0 / dx
+  J(1, 1) = 0.0;                   // dphi0 / dy
+  J(1, 2) = 0.0;                   // dphi0 / dz
+  J(1, 3) = -py / std::pow(pt, 2); // dphi0 / dpx
+  J(1, 4) = px / std::pow(pt, 2);  // dphi0 / dpy
   J(1, 5) = 0.0;                   // dphi0 / dpz
 
-  // omega = (a * Bz / pt);
-  J(2, 0) = 0.0;                           // domega / dx_PCA
-  J(2, 1) = 0.0;                           // domega / dy_PCA
-  J(2, 2) = 0.0;                           // domega / dz_PCA
-  J(2, 3) = -omega * px / std::pow(pt, 2); // domega / dpx
-  J(2, 4) = -omega * py / std::pow(pt, 2); // domega / dpy
-  J(2, 5) = 0.0;                           // domega / dpz
+  // omega = q * a * Bz / pt, with pt = sqrt(px^2 + py^2)
+  double pt2 = px * px + py * py;
+
+  // domega / dx_PCA, domega / dy_PCA, domega / dz_PCA
+  J(2, 0) = 0.0; // domega / dx_PCA
+  J(2, 1) = 0.0; // domega / dy_PCA
+  J(2, 2) = 0.0; // domega / dz_PCA
+
+  // domega / dpx
+  J(2, 3) = -omega * px / pt2; // domega / dpx
+
+  // domega / dpy
+  J(2, 4) = -omega * py / pt2; // domega / dpy
+
+  // domega / dpz
+  J(2, 5) = 0.0; // domega / dpz = 0
 
   // z0 = P^0_z - P^r_z
   J(3, 0) = 0.0; // dz0 / dx_PCA
@@ -1306,15 +1352,15 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
   TMatrixD Jt(TMatrixD::kTransposed, J);
   TMatrixD tmp = J * C_cartesian * Jt;
 
-  TMatrixDSym C_helix(6);
+  TMatrixDSym C_helix(5);
   C_helix.Zero();
-  for (int i = 0; i < 6; ++i) {
+  for (int i = 0; i < 5; ++i) {
     for (int j = 0; j <= i; ++j) {
       C_helix(i, j) = tmp(i, j);
     }
   }
-  for (int i = 0; i < 6; ++i) {
-    for (int j = i + 1; j < 6; ++j) {
+  for (int i = 0; i < 5; ++i) {
+    for (int j = i + 1; j < 5; ++j) {
       C_helix(i, j) = C_helix(j, i);
     }
   }
@@ -1393,10 +1439,11 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
   Edm4hepTrackState.referencePoint = edm4hep::Vector3f(x_ref / dd4hep::mm, y_ref / dd4hep::mm, z_ref / dd4hep::mm);
   Edm4hepTrackState.location = location;
 
-  TMatrixDSym CovHelix = CovarianceMatrixCartesianToHelix(covariancePosMom, gen_momentum, Bz);
+  TMatrixDSym CovHelix = CovarianceMatrixCartesianToHelix(covariancePosMom, gen_position, gen_momentum,
+                                                          m_VP_referencePoint, m_charge_hypothesis, Bz);
 
-  // Conversion from TMatrixDSym(6x6) to lower-triangular packed format used in edm4hep::TrackState
-  for (int i = 0; i < 6; ++i) {
+  // Conversion from TMatrixDSym(5x5) to lower-triangular packed format used in edm4hep::TrackState
+  for (int i = 0; i < 5; ++i) {
     for (int j = 0; j <= i; ++j) {
       Edm4hepTrackState.setCovMatrix(static_cast<float>(CovHelix(i, j)), static_cast<edm4hep::TrackParams>(i),
                                      static_cast<edm4hep::TrackParams>(j));

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -1276,14 +1276,16 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
   double py = Momentum_gev.Y();
   double pz = Momentum_gev.Z();
 
-  double x_PCA = Position_cm.X();
-  double y_PCA = Position_cm.Y();
+  double x_PCA_mm = Position_cm.X() / dd4hep::mm;
+  double y_PCA_mm = Position_cm.Y() / dd4hep::mm;
+  double RefX_mm = RefPoint_cm.X() / dd4hep::mm;
+  double RefY_mm = RefPoint_cm.Y() / dd4hep::mm;
 
   double pt = Momentum_gev.Perp();
 
   double phi0 = std::atan2(py, px);
   double tanLambda = pz / pt;
-  double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)) * dd4hep::mm;
+  double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)); // in 1/mm
 
   if (Bz * Charge < 0)
     omega = -omega;
@@ -1301,7 +1303,7 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
   J(0, 2) = 0.0;        // dd0 / dz
 
   // chain rule via phi0 = atan2(py, px)
-  double dd0_dphi = -(RefPoint_cm.X() - x_PCA) * cos(phi0) - (RefPoint_cm.Y() - y_PCA) * sin(phi0);
+  double dd0_dphi = -(RefX_mm - x_PCA_mm) * cos(phi0) - (RefY_mm - y_PCA_mm) * sin(phi0);
 
   J(0, 3) = dd0_dphi * (-py / (pt * pt)); // dd0 / dpx
   J(0, 4) = dd0_dphi * (px / (pt * pt));  // dd0 / dpy

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -1232,6 +1232,16 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
   return C_cart;
 }
 
+/**
+ * @brief Propagation of the covariance matrix from cartesian-parameter representation to Helix coordinate
+ * representation
+ *
+ * @param C_cartesian    Covariance Matrix in cartesian-basis
+ * @param Momentum_gev   Initial Momentum in gev/c
+ * @param Bz             Bz
+ *
+ * @return Covariance matrix in helix-basis
+ */
 TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6
                                                           TVector3 Momentum_gev, double Bz) {
 

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -1232,6 +1232,86 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
   return C_cart;
 }
 
+TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6
+                                                          TVector3 Momentum_gev, double Bz) {
+
+  double px = Momentum_gev.X();
+  double py = Momentum_gev.Y();
+  double pz = Momentum_gev.Z();
+
+  double pt = Momentum_gev.Perp();
+
+  double phi0 = std::atan2(py, px);
+  double tanLambda = pz / pt;
+  double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)) * dd4hep::mm;
+
+  // --- Jacobian (5x6) ---
+  TMatrixD J(5, 6);
+  J.Zero();
+
+  // These definitions are taken from
+  // https://flc.desy.de/lcnotes/notes/localfsExplorer_read?currentPath=/afs/desy.de/group/flc/lcnotes/LC-DET-2006-004.pdf
+
+  // d0 = -(RefPoint_cm.X() - x_PCA) * sin(phi0) + (RefPoint_cm.Y() - y_PCA) * cos(phi0);
+  J(0, 0) = sin(phi0); // dd0 / dx_PCA
+  J(0, 1) = cos(phi0); // dd0 / dy_PCA
+  J(0, 2) = 0.0;       // dd0 / dz_PCA
+  J(0, 3) = 0.0;       // dd0 / dpx
+  J(0, 4) = 0.0;       // dd0 / dpy
+  J(0, 5) = 0.0;       // dd0 / dpz
+
+  // phi0 = atan2(py, px);
+  J(1, 0) = -py / std::pow(pt, 2); // dphi0 / dx_PCA
+  J(1, 1) = px / std::pow(pt, 2);  // dphi0 / dy_PCA
+  J(1, 2) = 0.0;                   // dphi0 / dz_PCA
+  J(1, 3) = 0.0;                   // dphi0 / dpx
+  J(1, 4) = 0.0;                   // dphi0 / dpy
+  J(1, 5) = 0.0;                   // dphi0 / dpz
+
+  // omega = (a * Bz / pt);
+  J(2, 0) = 0.0;                           // domega / dx_PCA
+  J(2, 1) = 0.0;                           // domega / dy_PCA
+  J(2, 2) = 0.0;                           // domega / dz_PCA
+  J(2, 3) = -omega * px / std::pow(pt, 2); // domega / dpx
+  J(2, 4) = -omega * py / std::pow(pt, 2); // domega / dpy
+  J(2, 5) = 0.0;                           // domega / dpz
+
+  // z0 = P^0_z - P^r_z
+  J(3, 0) = 0.0; // dz0 / dx_PCA
+  J(3, 1) = 0.0; // dz0 / dy_PCA
+  J(3, 2) = 1.0; // dz0 / dz_PCA
+  J(3, 3) = 0.0; // dz0 / dpx
+  J(3, 4) = 0.0; // dz0 / dpy
+  J(3, 5) = 0.0; // dz0 / dpz
+
+  // tanLambda = pz / pt
+  J(4, 0) = 0.0;                               // dtanLambda / dx_PCA
+  J(4, 1) = 0.0;                               // dtanLambda / dy_PCA
+  J(4, 2) = 0.0;                               // dtanLambda / dz_PCA
+  J(4, 3) = -tanLambda * px / std::pow(pt, 2); // dtanLambda / dpx
+  J(4, 4) = -tanLambda * py / std::pow(pt, 2); // dtanLambda / dpy
+  J(4, 5) = 1.0 / pt;                          // dtanLambda / dpz
+
+  // --- Compute C_cart = J * C_helix * J^T ---
+  TMatrixD Jt(TMatrixD::kTransposed, J);
+  TMatrixD tmp = J * C_cartesian * Jt;
+
+  TMatrixDSym C_helix(6);
+  C_helix.Zero();
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j <= i; ++j) {
+      C_helix(i, j) = tmp(i, j);
+    }
+  }
+  for (int i = 0; i < 6; ++i) {
+    for (int j = i + 1; j < 6; ++j) {
+      C_helix(i, j) = C_helix(j, i);
+    }
+  }
+
+  return C_helix;
+}
+
 /**
  * @brief Update an edm4hep::TrackState using the fitted Genfit state parameters.
  *
@@ -1302,6 +1382,16 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
 
   Edm4hepTrackState.referencePoint = edm4hep::Vector3f(x_ref / dd4hep::mm, y_ref / dd4hep::mm, z_ref / dd4hep::mm);
   Edm4hepTrackState.location = location;
+
+  TMatrixDSym CovHelix = CovarianceMatrixCartesianToHelix(covariancePosMom, gen_momentum, Bz);
+
+  // Conversion from TMatrixDSym(6x6) to lower-triangular packed format used in edm4hep::TrackState
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j <= i; ++j) {
+      Edm4hepTrackState.setCovMatrix(static_cast<float>(CovHelix(i, j)), static_cast<edm4hep::TrackParams>(i),
+                                     static_cast<edm4hep::TrackParams>(j));
+    }
+  }
 
   return Edm4hepTrackState;
 }

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -1452,6 +1452,25 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
     }
   }
 
+  std::cout << "\n===== Helix parameters with uncertainties =====\n";
+
+  // helper lambda
+  auto printParam = [](const std::string& name, double value, double err) {
+    std::cout << name << " = " << value << " ± " << err << "\n";
+  };
+
+  double d0_err        = std::sqrt(CovHelix(0,0));
+  double phi_err       = std::sqrt(CovHelix(1,1));
+  double omega_err     = std::sqrt(CovHelix(2,2));
+  double z0_err        = std::sqrt(CovHelix(3,3));
+  double tanL_err      = std::sqrt(CovHelix(4,4));
+
+  printParam("d0       ", d0, d0_err);
+  printParam("phi      ", phi, phi_err);
+  printParam("omega    ", omega, omega_err);
+  printParam("z0       ", z0, z0_err);
+  printParam("tanLambda", tanLambda, tanL_err);
+
   return Edm4hepTrackState;
 }
 

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -329,7 +329,7 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
         found = true;
 
         m_VP_referencePoint = TVector3(ts.referencePoint.x * dd4hep::mm, ts.referencePoint.y * dd4hep::mm,
-                                       ts.referencePoint.z * dd4hep::mm);
+                                       ts.referencePoint.z * dd4hep::mm); // in cm
 
         double Bz =
             m_fieldMap->getBz(m_VP_referencePoint) / (dd4hep::tesla / dd4hep::kilogauss); // From kilogauss to Tesla
@@ -360,6 +360,20 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
         for (int i = 0; i < 5; ++i) {
           for (int j = i + 1; j < 5; ++j) {
             C_helix(i, j) = C_helix(j, i);
+          }
+        }
+
+        // Conversion factors:
+        // d0 : mm -> cm
+        // phi0 : unchanged
+        // omega : 1/mm -> 1/cm => x10
+        // z0 : mm -> cm        => x0.1
+        // tanLambda : unchanged
+
+        double scale[5] = {dd4hep::mm, dd4hep::cm, 1. / dd4hep::mm, dd4hep::mm, dd4hep::cm};
+        for (int i = 0; i < 5; ++i) {
+          for (int j = 0; j < 5; ++j) {
+            C_helix(i, j) *= scale[i] * scale[j];
           }
         }
 
@@ -549,8 +563,8 @@ void GenfitTrack::LimitNumberHits(double epsilon, int smoothWindow) {
  *
  * @param Bz Magnetic field component along the z axis.
  * @param Charge Particle charge hypothesis (+1 or -1).
- * @param sigma_d0 Optional uncertainty on d0 (default 0.05).
- * @param sigma_phi Optional uncertainty on phi (default 0.1).
+ * @param sigma_d0 Optional uncertainty on d0 [cm] (default 0.05).
+ * @param sigma_phi Optional uncertainty on phi [rad] (default 0.1).
  * @param omega_factor Scaling factor for curvature uncertainty (default 0.5).
  * @param z0_factor Scaling factor for z0 uncertainty (default 0.1).
  * @param sigma_tanLambda Optional uncertainty on tanLambda (default 0.1).
@@ -565,20 +579,20 @@ TMatrixDSym GenfitTrack::ComputeInitialCovarianceMatrix(double Bz, int Charge, s
   TMatrixDSym C_helix(5);
   C_helix.Zero();
 
-  // d0
+  // d0 (in cm)
   double sd0 = sigma_d0.value_or(0.05);
   C_helix(0, 0) = sd0 * sd0;
 
-  // phi
+  // phi (in rad)
   double sphi = sigma_phi.value_or(0.1);
   C_helix(1, 1) = sphi * sphi;
 
-  // omega
+  // omega (in 1/cm)
   double pt = m_momInit.Perp();
-  double omega = std::abs(ConversionUnits::a_lcio * Bz / pt * dd4hep::mm);
+  double omega = std::abs(ConversionUnits::a_lcio * Bz / pt * dd4hep::mm); // in 1/cm
   C_helix(2, 2) = std::pow(omega_factor.value_or(0.5) * omega, 2);
 
-  // z0
+  // z0 (in cm)
   double z0_scale = std::abs(m_posInit.Z());
   C_helix(3, 3) = std::pow(z0_factor.value_or(0.1) * z0_scale, 2);
 
@@ -647,7 +661,7 @@ TMatrixDSym GenfitTrack::ComputeInitialCovarianceMatrix(double Bz, int Charge, s
  */
 GenfitTrack::HelperInitialization GenfitTrack::ComputeInitialParameters(double Bz) {
 
-  Point2D_xy referencePoint_xy(m_VP_referencePoint.X() / dd4hep::mm, m_VP_referencePoint.Y() / dd4hep::mm);
+  Point2D_xy referencePoint_xy(m_VP_referencePoint.X() / dd4hep::mm, m_VP_referencePoint.Y() / dd4hep::mm); // in mm
 
   auto hits = m_edm4hepTrack.getTrackerHits();
   const size_t N = hits.size();
@@ -723,7 +737,7 @@ GenfitTrack::HelperInitialization GenfitTrack::ComputeInitialParameters(double B
 
   // Output
   HelperInitialization helper;
-  helper.Position = TVector3(closestPoint.x * dd4hep::mm, closestPoint.y * dd4hep::mm, z_PCA * dd4hep::mm);
+  helper.Position = TVector3(closestPoint.x * dd4hep::mm, closestPoint.y * dd4hep::mm, z_PCA * dd4hep::mm); // in cm
 
   helper.Momentum = init_mom;
   helper.Charge = charge;
@@ -1135,7 +1149,7 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
  * @brief Propagation of the covariance matrix from helix-parameter representation to Cartesian coordinate
  * representation
  *
- * @param C_helix        Covariance Matrix in helix-basis
+ * @param C_helix        Covariance Matrix in helix-basis (cm and GeV units)
  * @param Position_cm    Inizial Position in cm
  * @param Momentum_gev   Initial Momentum in gev/c
  * @param RefPoint_cm    Reference position (e.g. IP)
@@ -1160,7 +1174,7 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
 
   double d0 = -(RefPoint_cm.X() - x_PCA) * sin(phi0) + (RefPoint_cm.Y() - y_PCA) * cos(phi0);
 
-  double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)) * dd4hep::mm;
+  double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)) * dd4hep::mm; // in 1/cm
 
   if (Bz * Charge < 0)
     omega = -omega;
@@ -1259,14 +1273,14 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
  * @brief Propagation of the covariance matrix from cartesian-parameter representation to Helix coordinate
  * representation
  *
- * @param C_cartesian    Covariance Matrix in cartesian-basis
+ * @param C_cartesian    Covariance Matrix in cartesian-basis (cm and GeV units)
  * @param Position_cm    Inizial Position in cm
  * @param Momentum_gev   Initial Momentum in gev/c
  * @param RefPoint_cm    Reference position (e.g. IP)
  * @param Charge         Charge hypothesis
  * @param Bz             Bz
  *
- * @return Covariance matrix in helix-basis
+ * @return Covariance matrix in helix-basis (mm and GeV units)
  */
 TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6
                                                           TVector3 Position_cm, TVector3 Momentum_gev,
@@ -1418,7 +1432,8 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
   double pt = gen_momentum.Perp(); // gev
 
   double Bz = m_fieldMap->getBz(gen_position) / (dd4hep::tesla / dd4hep::kilogauss); // From kilogauss to Tesla
-  auto infoComputeD0Z0_firstHit = PCAInfo(gen_position, gen_momentum, m_charge_hypothesis, m_VP_referencePoint, Bz);
+  auto infoComputeD0Z0_firstHit =
+      PCAInfo(gen_position, gen_momentum, m_charge_hypothesis, m_VP_referencePoint, Bz); // in cm
 
   double d0 = ((-(m_VP_referencePoint.X() - infoComputeD0Z0_firstHit.PCA.X())) * sin(infoComputeD0Z0_firstHit.Phi0) +
                (m_VP_referencePoint.Y() - infoComputeD0Z0_firstHit.PCA.Y()) * cos(infoComputeD0Z0_firstHit.Phi0)) /
@@ -1475,15 +1490,15 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
  * 7. Calculate the azimuthal angle `Phi0` of the tangent.
  * 8. Compute the z-coordinate of the PCA along the helix using the straight-line approximation.
  *
- * @param position  Initial 3D position of the particle.
- * @param momentum  3D momentum vector of the particle.
+ * @param position  Initial 3D position of the particle (in cm).
+ * @param momentum  3D momentum vector of the particle (in GeV/c).
  * @param charge    Particle charge (in e units).
- * @param refPoint  Reference point to which the PCA is calculated.
+ * @param refPoint  Reference point to which the PCA is calculated (in cm).
  * @param Bz        Magnetic field along the z-axis (Tesla).
  *
  * @return A `PCAInfoHelper` structure containing:
- *         - `PCA`   : The 3D position of the closest approach point.
- *         - `Phi0`  : Azimuthal angle of the trajectory at the PCA (radians).
+ *         - `PCA`   : The 3D position of the closest approach point (in cm).
+ *         - `Phi0`  : Azimuthal angle of the trajectory at the PCA (in rad).
  *
  * @note Assumes a uniform magnetic field along z and a simple helical trajectory.
  */

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -1452,25 +1452,6 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
     }
   }
 
-  std::cout << "\n===== Helix parameters with uncertainties =====\n";
-
-  // helper lambda
-  auto printParam = [](const std::string& name, double value, double err) {
-    std::cout << name << " = " << value << " ± " << err << "\n";
-  };
-
-  double d0_err        = std::sqrt(CovHelix(0,0));
-  double phi_err       = std::sqrt(CovHelix(1,1));
-  double omega_err     = std::sqrt(CovHelix(2,2));
-  double z0_err        = std::sqrt(CovHelix(3,3));
-  double tanL_err      = std::sqrt(CovHelix(4,4));
-
-  printParam("d0       ", d0, d0_err);
-  printParam("phi      ", phi, phi_err);
-  printParam("omega    ", omega, omega_err);
-  printParam("z0       ", z0, z0_err);
-  printParam("tanLambda", tanLambda, tanL_err);
-
   return Edm4hepTrackState;
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Correct the data type of phi0 when saving it in PCAInfo
- Correct the sign of omega by properly determining the particle charge during initialization
- Add covariance matrix to fitted trackStates
- Fix how filtered tracks are saved in the output file: now for each fitted track there is the corresponding filtered track
- Expose EDM4Hep units to the user

ENDRELEASENOTES

Hello everyone,

This pull request is opened to address a couple of issues identified in the current reconstruction: 

- correction of the phi0 type when storing it in PCAInfo
- improvement of the omega sign determination through a correct charge estimation during initialization
- Implementation of the covariance matrix for fitted trackStates

Thank you!

Andrea