### PR TITLE
Remove the deprecated k4DataSvc and PodioOutput

### DIFF
--- a/ARCdigi/test/runARCdigitizer.py
+++ b/ARCdigi/test/runARCdigitizer.py
@@ -1,8 +1,8 @@
 import os
 from Gaudi.Configuration import *
-from Configurables import ApplicationMgr
 
-from Configurables import GeoSvc
+from Configurables import GeoSvc, EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
 
 geoservice = GeoSvc("GeoSvc")
 path_to_detector = os.environ.get("LCGEO")
@@ -11,28 +11,17 @@ detectors_to_use = [
 ]
 geoservice.detectors = [os.path.join(path_to_detector, _det) for _det in detectors_to_use]
 
-from Configurables import k4DataSvc
-
-dataservice = k4DataSvc(
-    "EventDataSvc", input=vars().get("input", "data/arcsim_kaon+_edm4hep.root")
-)
-
-from Configurables import PodioInput
-
-podioinput = PodioInput("PodioInput", collections=["ARC_HITS"], OutputLevel=DEBUG)
+iosvc = IOSvc()
+iosvc.Input = vars().get("input", "data/arcsim_kaon+_edm4hep.root")
+iosvc.CollectionNames = ["ARC_HITS"]
+iosvc.Output = vars().get("output", "digi.root")
+iosvc.outputCommands = ["keep *"]
 
 from Configurables import ARCdigitizer
 
 arc_digitizer = ARCdigitizer(
     "ARCdigitizer", inputSimHits="ARC_HITS", outputDigiHits="ARC_DIGI_HITS"
 )
-
-from Configurables import PodioOutput
-
-podiooutput = PodioOutput(
-    "PodioOutput", filename=vars().get("output", "digi.root"), OutputLevel=DEBUG
-)
-podiooutput.outputCommands = ["keep *"]
 
 # CPU information
 from Configurables import AuditorSvc, ChronoAuditor
@@ -41,11 +30,10 @@ chra = ChronoAuditor()
 audsvc = AuditorSvc()
 audsvc.Auditors = [chra]
 arc_digitizer.AuditExecute = True
-podiooutput.AuditExecute = True
 
 ApplicationMgr(
-    TopAlg=[podioinput, arc_digitizer, podiooutput],
+    TopAlg=[arc_digitizer],
     EvtSel="NONE",
     EvtMax=10,
-    ExtSvc=[geoservice, dataservice],
+    ExtSvc=[geoservice, EventDataSvc("EventDataSvc")],
 )

--- a/DCHdigi/test/runDCHsimpleDigitizer.py
+++ b/DCHdigi/test/runDCHsimpleDigitizer.py
@@ -2,9 +2,10 @@ import os
 
 from Gaudi.Configuration import *
 
-from Configurables import FCCDataSvc
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
 
-podioevent = FCCDataSvc("EventDataSvc")
+podioevent = EventDataSvc("EventDataSvc")
 
 from GaudiKernel.SystemOfUnits import MeV, GeV, tesla
 
@@ -142,14 +143,8 @@ dch_digitizer = DCHsimpleDigitizer(
 )
 
 ################ Output
-from Configurables import PodioOutput
-
-out = PodioOutput("out", OutputLevel=INFO)
-out.outputCommands = ["keep *"]
-
-import uuid
-
-out.filename = (
+iosvc = IOSvc()
+iosvc.Output = (
     "output_simplifiedDriftChamber_MagneticField_"
     + str(magneticField)
     + "_pMin_"
@@ -163,6 +158,7 @@ out.filename = (
     + str(pdgCode)
     + ".root"
 )
+iosvc.outputCommands = ["keep *"]
 
 # CPU information
 from Configurables import AuditorSvc, ChronoAuditor
@@ -173,12 +169,9 @@ audsvc.Auditors = [chra]
 genAlg.AuditExecute = True
 hepmc_converter.AuditExecute = True
 geantsim.AuditExecute = True
-out.AuditExecute = True
-
-from Configurables import ApplicationMgr
 
 ApplicationMgr(
-    TopAlg=[genAlg, hepmc_converter, geantsim, dch_digitizer, out],
+    TopAlg=[genAlg, hepmc_converter, geantsim, dch_digitizer],
     EvtSel="NONE",
     EvtMax=10,
     ExtSvc=[geoservice, podioevent, geantservice, audsvc],

--- a/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
+++ b/DCHdigi/test/runDCHsimpleDigitizerExtendedEdm.py
@@ -2,9 +2,10 @@ import os
 
 from Gaudi.Configuration import *
 
-from Configurables import FCCDataSvc
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
 
-podioevent = FCCDataSvc("EventDataSvc")
+podioevent = EventDataSvc("EventDataSvc")
 
 from GaudiKernel.SystemOfUnits import MeV, GeV, tesla
 
@@ -174,17 +175,8 @@ dch_digitizer = DCHsimpleDigitizerExtendedEdm(
 
 
 ################ Output
-from Configurables import PodioOutput
-
-out = PodioOutput("out", OutputLevel=INFO)
-out.outputCommands = ["keep *"]
-if not dch_digitizer.debugMode:
-    out.outputCommands.append("drop *HitSimHitDelta*")
-    out.outputCommands.append("drop outputDigiLocalHits")
-
-import uuid
-
-out.filename = (
+iosvc = IOSvc()
+iosvc.Output = (
     "output_simplifiedDriftChamber_MagneticField_"
     + str(magneticField)
     + "_pMin_"
@@ -198,6 +190,10 @@ out.filename = (
     + str(pdgCode)
     + "_stepLength_default.root"
 )
+iosvc.outputCommands = ["keep *"]
+if not dch_digitizer.debugMode:
+    iosvc.outputCommands.append("drop *HitSimHitDelta*")
+    iosvc.outputCommands.append("drop outputDigiLocalHits")
 
 # CPU information
 from Configurables import AuditorSvc, ChronoAuditor
@@ -208,9 +204,6 @@ audsvc.Auditors = [chra]
 genAlg.AuditExecute = True
 hepmc_converter.AuditExecute = True
 geantsim.AuditExecute = True
-out.AuditExecute = True
-
-from Configurables import ApplicationMgr
 
 ApplicationMgr(
     TopAlg=[
@@ -219,7 +212,6 @@ ApplicationMgr(
         geantsim,
         dch_digitizer,
         # dch_perf,
-        out,
     ],
     EvtSel="NONE",
     EvtMax=100,

--- a/VTXdigi/test/runVTXdigitizer.py
+++ b/VTXdigi/test/runVTXdigitizer.py
@@ -2,9 +2,10 @@ import os, math
 
 from Gaudi.Configuration import *
 
-from Configurables import FCCDataSvc
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
 
-podioevent = FCCDataSvc("EventDataSvc")
+podioevent = EventDataSvc("EventDataSvc")
 
 from GaudiKernel.SystemOfUnits import MeV, GeV, tesla
 
@@ -314,14 +315,8 @@ idea_siwrd_digitizer = VTXdigitizer(
 # genfitter = GenFitter("GenFitter", inputHits = savetrackertool.SimTrackHits.Path.replace("sim", "digi"), outputTracks = "genfit_tracks")
 
 ################ Output
-from Configurables import PodioOutput
-
-out = PodioOutput("out", OutputLevel=INFO)
-out.outputCommands = ["keep *"]
-
-import uuid
-
-out.filename = (
+iosvc = IOSvc()
+iosvc.Output = (
     "output_vertex_"
     + str(magneticField)
     + "_pMin_"
@@ -335,6 +330,7 @@ out.filename = (
     + str(pdgCode)
     + ".root"
 )
+iosvc.outputCommands = ["keep *"]
 
 # CPU information
 from Configurables import AuditorSvc, ChronoAuditor
@@ -345,9 +341,6 @@ audsvc.Auditors = [chra]
 genAlg.AuditExecute = True
 hepmc_converter.AuditExecute = True
 geantsim.AuditExecute = True
-out.AuditExecute = True
-
-from Configurables import ApplicationMgr
 
 # # CLD
 # ApplicationMgr(
@@ -374,7 +367,6 @@ ApplicationMgr(
         idea_vtxd_digitizer,
         idea_siwrb_digitizer,
         idea_siwrd_digitizer,
-        out,
     ],
     EvtSel="NONE",
     EvtMax=10,

--- a/VTXdigiDetailed/test/py_utils.py
+++ b/VTXdigiDetailed/test/py_utils.py
@@ -21,7 +21,7 @@ from typing import Union, Optional, Dict, Any, List
 import importlib.util
 import importlib.abc
 from importlib.machinery import SourceFileLoader
-from Configurables import PodioOutput, MarlinProcessorWrapper
+from Configurables import MarlinProcessorWrapper
 from typing import Iterable
 from Gaudi.Configuration import WARNING
 

--- a/share/runDigi.py
+++ b/share/runDigi.py
@@ -1,33 +1,22 @@
 from Gaudi.Configuration import *
-from Configurables import ApplicationMgr
 
-from Configurables import GeoSvc
+from Configurables import GeoSvc, EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
 
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors.append("/path/to/k4geo/FCCee/compact/CLD_ARC/arc_full_v0.xml")
 
-from Configurables import k4DataSvc
-
-dataservice = k4DataSvc(
-    "EventDataSvc", input=vars().get("input", "data/arcsim_kaon+_edm4hep.root")
-)
-
-from Configurables import PodioInput
-
-podioinput = PodioInput("PodioInput", collections=["ARC_HITS"], OutputLevel=DEBUG)
+iosvc = IOSvc()
+iosvc.Input = vars().get("input", "data/arcsim_kaon+_edm4hep.root")
+iosvc.CollectionNames = ["ARC_HITS"]
+iosvc.Output = vars().get("output", "digi.root")
+iosvc.outputCommands = ["keep *"]
 
 from Configurables import ARCdigitizer
 
 arc_digitizer = ARCdigitizer(
     "ARCdigitizer", inputSimHits="ARC_HITS", outputDigiHits="ARC_DIGI_HITS"
 )
-
-from Configurables import PodioOutput
-
-podiooutput = PodioOutput(
-    "PodioOutput", filename=vars().get("output", "digi.root"), OutputLevel=DEBUG
-)
-podiooutput.outputCommands = ["keep *"]
 
 # CPU information
 from Configurables import AuditorSvc, ChronoAuditor
@@ -36,7 +25,6 @@ chra = ChronoAuditor()
 audsvc = AuditorSvc()
 audsvc.Auditors = [chra]
 arc_digitizer.AuditExecute = True
-podiooutput.AuditExecute = True
 
 from Configurables import EventCounter
 
@@ -44,8 +32,8 @@ event_counter = EventCounter("event_counter")
 event_counter.Frequency = 1
 
 ApplicationMgr(
-    TopAlg=[event_counter, podioinput, arc_digitizer, podiooutput],
+    TopAlg=[event_counter, arc_digitizer],
     EvtSel="NONE",
     EvtMax=10,
-    ExtSvc=[geoservice, dataservice],
+    ExtSvc=[geoservice, EventDataSvc("EventDataSvc")],
 )


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the deprecated k4DataSvc and PodioOutput, following https://github.com/key4hep/k4FWCore/pull/392

ENDRELEASENOTES