### PR TITLE
Add MUONdigitizer: cluster-based digitizer for IDEA muon system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_subdirectory(DCHdigi)
 add_subdirectory(ARCdigi)
 add_subdirectory(VTXdigi)
 add_subdirectory(VTXdigiDetailed)
+add_subdirectory(MUONdigi)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 add_subdirectory(Tracking)
 

--- a/MUONdigi/CMakeLists.txt
+++ b/MUONdigi/CMakeLists.txt
@@ -1,0 +1,46 @@
+set(PackageName MUONdigi)
+
+project(${PackageName})
+
+file(GLOB sources
+    ${PROJECT_SOURCE_DIR}/src/*.cpp
+)
+
+file(GLOB headers
+  ${PROJECT_SOURCE_DIR}/include/*.h
+)
+
+gaudi_add_module(${PackageName}
+  SOURCES ${sources}
+  LINK
+  Gaudi::GaudiKernel
+  EDM4HEP::edm4hep
+  k4FWCore::k4FWCore
+  k4FWCore::k4Interface
+  DD4hep::DDRec
+)
+
+target_include_directories(${PackageName} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+set_target_properties(${PackageName} PROPERTIES PUBLIC_HEADER "${headers}")
+
+file(GLOB scripts
+  ${PROJECT_SOURCE_DIR}/test/*.py
+)
+
+file(COPY ${scripts} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/test)
+
+install(TARGETS ${PackageName}
+  EXPORT ${CMAKE_PROJECT_NAME}Targets
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME}" COMPONENT dev
+)
+
+install(FILES ${scripts} DESTINATION test)
+
+SET(test_name "test_MUONDigitizer")
+ADD_TEST(NAME t_${test_name} COMMAND k4run test/runMUONDigitizer.py)

--- a/MUONdigi/include/MUONDigitizer.h
+++ b/MUONdigi/include/MUONDigitizer.h
@@ -19,17 +19,17 @@
 
 // DD4HEP
 #include "DD4hep/Detector.h"
-#include "DDRec/Vector3D.h"
 #include "DDRec/SurfaceManager.h"
+#include "DDRec/Vector3D.h"
 #include "DDSegmentation/BitFieldCoder.h"
 
-#include <vector>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <limits>
 #include <map>
 #include <set>
+#include <vector>
 
 /** @class MUONDigitizer
  *
@@ -64,23 +64,21 @@ public:
 
 private:
   // ---- Input / output collections --------------------------------------
-  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{
-      "inputSimHits", Gaudi::DataHandle::Reader, this};
-  mutable k4FWCore::DataHandle<edm4hep::TrackerHitPlaneCollection> m_output_digi_hits{
-      "outputDigiHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits",
+                                                                                  Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHitPlaneCollection> m_output_digi_hits{"outputDigiHits",
+                                                                                      Gaudi::DataHandle::Writer, this};
   mutable k4FWCore::DataHandle<edm4hep::TrackerHitSimTrackerHitLinkCollection> m_output_sim_digi_link{
       "outputSimDigiLink", Gaudi::DataHandle::Writer, this};
 
   // ---- Geometry --------------------------------------------------------
-  Gaudi::Property<std::string> m_detectorName{
-      this, "detectorName", "Muon-System",
-      "DD4hep detector name"};
-  Gaudi::Property<std::string> m_readoutName{
-      this, "readoutName", "MuonSystemCollection", "Name of the detector readout"};
+  Gaudi::Property<std::string> m_detectorName{this, "detectorName", "Muon-System", "DD4hep detector name"};
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "MuonSystemCollection",
+                                             "Name of the detector readout"};
   ServiceHandle<IGeoSvc> m_geoSvc;
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder = nullptr;
   dd4hep::VolumeManager m_volman;
-  const dd4hep::rec::SurfaceMap* m_surfMap = nullptr;  // populated only when forceHitsOntoSurface is true
+  const dd4hep::rec::SurfaceMap* m_surfMap = nullptr; // populated only when forceHitsOntoSurface is true
 
   // ---- Smearing / efficiency / clustering knobs ------------------------
   // uRWELL is a planar 2D readout: the chamber-local x is the gas-gap normal
@@ -90,38 +88,35 @@ private:
                                "Spatial resolution along surface u (= local y, in-plane) [mm]"};
   FloatProperty m_v_resolution{this, "vResolution", 0.4,
                                "Spatial resolution along surface v (= local z, in-plane) [mm]"};
-  FloatProperty m_t_resolution{this, "tResolution", -1.0,
-                               "Time resolution [ns]; <=0 disables time smearing (digi time = earliest contributing SimHit time)"};
-  FloatProperty m_efficiency{this, "efficiency", 0.98,
-                             "Per-cluster detection efficiency"};
-  FloatProperty m_timeWindow{this, "timeWindow", 25.0,
-                             "Time window for grouping SimHits into the same cluster [ns]"};
+  FloatProperty m_t_resolution{
+      this, "tResolution", -1.0,
+      "Time resolution [ns]; <=0 disables time smearing (digi time = earliest contributing SimHit time)"};
+  FloatProperty m_efficiency{this, "efficiency", 0.98, "Per-cluster detection efficiency"};
+  FloatProperty m_timeWindow{this, "timeWindow", 25.0, "Time window for grouping SimHits into the same cluster [ns]"};
   Gaudi::Property<unsigned int> m_maxClusterSize{
-      this, "maxClusterSize", 3,
-      "Maximum number of distinct strip indices per view (Y and Z) inside one cluster"};
+      this, "maxClusterSize", 3, "Maximum number of distinct strip indices per view (Y and Z) inside one cluster"};
   BooleanProperty m_forceHitsOntoSurface{
       this, "forceHitsOntoSurface", false,
       "If true, project smeared digi positions that fall outside the chamber sensitive surface back onto it"};
   Gaudi::Property<unsigned int> m_printFrequency{
-      this, "printFrequency", 100,
-      "Print one INFO line every N events with the in/out hit count (0 = never)"};
+      this, "printFrequency", 100, "Print one INFO line every N events with the in/out hit count (0 = never)"};
 
   // ---- Validation outputs ----------------------------------------------
-  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceX{
-      "simDigiDifferenceX", Gaudi::DataHandle::Writer, this};
-  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceY{
-      "simDigiDifferenceY", Gaudi::DataHandle::Writer, this};
-  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceZ{
-      "simDigiDifferenceZ", Gaudi::DataHandle::Writer, this};
-  mutable k4FWCore::DataHandle<podio::UserDataCollection<int>> m_clusterSizeY{
-      "clusterSizeY", Gaudi::DataHandle::Writer, this};
-  mutable k4FWCore::DataHandle<podio::UserDataCollection<int>> m_clusterSizeZ{
-      "clusterSizeZ", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceX{"simDigiDifferenceX",
+                                                                                       Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceY{"simDigiDifferenceY",
+                                                                                       Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceZ{"simDigiDifferenceZ",
+                                                                                       Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<int>> m_clusterSizeY{"clusterSizeY", Gaudi::DataHandle::Writer,
+                                                                              this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<int>> m_clusterSizeZ{"clusterSizeZ", Gaudi::DataHandle::Writer,
+                                                                              this};
 
   // ---- Random services -------------------------------------------------
   SmartIF<IRndmGenSvc> m_randSvc;
-  mutable Rndm::Numbers m_gauss_u;  // smear along surface u (local y)
-  mutable Rndm::Numbers m_gauss_v;  // smear along surface v (local z)
-  mutable Rndm::Numbers m_gauss_t;  // smear time if tResolution > 0
+  mutable Rndm::Numbers m_gauss_u; // smear along surface u (local y)
+  mutable Rndm::Numbers m_gauss_v; // smear along surface v (local z)
+  mutable Rndm::Numbers m_gauss_t; // smear time if tResolution > 0
   mutable Rndm::Numbers m_flat;
 };

--- a/MUONdigi/include/MUONDigitizer.h
+++ b/MUONdigi/include/MUONDigitizer.h
@@ -1,0 +1,127 @@
+#pragma once
+
+// GAUDI
+#include "Gaudi/Algorithm.h"
+#include "Gaudi/Property.h"
+#include "GaudiKernel/IRndmGenSvc.h"
+#include "GaudiKernel/RndmGenerators.h"
+
+// K4FWCORE & podio
+#include "k4FWCore/DataHandle.h"
+#include "k4Interface/IGeoSvc.h"
+#include "podio/UserDataCollection.h"
+
+// EDM4HEP
+#include "edm4hep/SimTrackerHitCollection.h"
+#include "edm4hep/TrackerHitPlaneCollection.h"
+#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
+#include "edm4hep/Vector3d.h"
+
+// DD4HEP
+#include "DD4hep/Detector.h"
+#include "DDRec/Vector3D.h"
+#include "DDRec/SurfaceManager.h"
+#include "DDSegmentation/BitFieldCoder.h"
+
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <set>
+
+/** @class MUONDigitizer
+ *
+ *  Cluster-based digitizer for the IDEA muon system (uRWELL chambers).
+ *
+ *  Each Geant4 SimTrackerHit is first assigned to the (y,z) strip-cell
+ *  given by its cellID. Cells that share a chamber/slice and fall within
+ *  the same time window are then grouped into clusters:
+ *
+ *    1. Pick the unused fired cell with the highest summed energy (seed).
+ *    2. Greedily attach the highest-energy fired cell that is (N°2 -1)-neighbour-
+ *       adjacent to any cell already in the cluster, where N is the cluster size,
+ *        *as long as* doing so
+ *       keeps the number of distinct Y-strip indices and the number of
+ *       distinct Z-strip indices both within MaxClusterSize. This matches
+ *       the test-beam cluster-size definition (strips per view).
+ *    3. Emit one digi hit at the energy-weighted centroid plus optional
+ *       Gaussian smearing, apply per-cluster efficiency, and repeat.
+ *
+ *  @author Mahmoud Althakeel
+ *  @date   2026-06
+ */
+
+class MUONDigitizer : public Gaudi::Algorithm {
+public:
+  explicit MUONDigitizer(const std::string&, ISvcLocator*);
+  virtual ~MUONDigitizer();
+
+  virtual StatusCode initialize() final;
+  virtual StatusCode execute(const EventContext&) const final;
+  virtual StatusCode finalize() final;
+
+private:
+  // ---- Input / output collections --------------------------------------
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{
+      "inputSimHits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHitPlaneCollection> m_output_digi_hits{
+      "outputDigiHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHitSimTrackerHitLinkCollection> m_output_sim_digi_link{
+      "outputSimDigiLink", Gaudi::DataHandle::Writer, this};
+
+  // ---- Geometry --------------------------------------------------------
+  Gaudi::Property<std::string> m_detectorName{
+      this, "detectorName", "Muon-System",
+      "DD4hep detector name"};
+  Gaudi::Property<std::string> m_readoutName{
+      this, "readoutName", "MuonSystemCollection", "Name of the detector readout"};
+  ServiceHandle<IGeoSvc> m_geoSvc;
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = nullptr;
+  dd4hep::VolumeManager m_volman;
+  const dd4hep::rec::SurfaceMap* m_surfMap = nullptr;  // populated only when forceHitsOntoSurface is true
+
+  // ---- Smearing / efficiency / clustering knobs ------------------------
+  // uRWELL is a planar 2D readout: the chamber-local x is the gas-gap normal
+  // (not measured) and only the two
+  // in-plane surface axes (u = local y, v = local z) are smeared.
+  FloatProperty m_u_resolution{this, "uResolution", 0.4,
+                               "Spatial resolution along surface u (= local y, in-plane) [mm]"};
+  FloatProperty m_v_resolution{this, "vResolution", 0.4,
+                               "Spatial resolution along surface v (= local z, in-plane) [mm]"};
+  FloatProperty m_t_resolution{this, "tResolution", -1.0,
+                               "Time resolution [ns]; <=0 disables time smearing (digi time = earliest contributing SimHit time)"};
+  FloatProperty m_efficiency{this, "efficiency", 0.98,
+                             "Per-cluster detection efficiency"};
+  FloatProperty m_timeWindow{this, "timeWindow", 25.0,
+                             "Time window for grouping SimHits into the same cluster [ns]"};
+  Gaudi::Property<unsigned int> m_maxClusterSize{
+      this, "maxClusterSize", 3,
+      "Maximum number of distinct strip indices per view (Y and Z) inside one cluster"};
+  BooleanProperty m_forceHitsOntoSurface{
+      this, "forceHitsOntoSurface", false,
+      "If true, project smeared digi positions that fall outside the chamber sensitive surface back onto it"};
+  Gaudi::Property<unsigned int> m_printFrequency{
+      this, "printFrequency", 100,
+      "Print one INFO line every N events with the in/out hit count (0 = never)"};
+
+  // ---- Validation outputs ----------------------------------------------
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceX{
+      "simDigiDifferenceX", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceY{
+      "simDigiDifferenceY", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<double>> m_simDigiDifferenceZ{
+      "simDigiDifferenceZ", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<int>> m_clusterSizeY{
+      "clusterSizeY", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<int>> m_clusterSizeZ{
+      "clusterSizeZ", Gaudi::DataHandle::Writer, this};
+
+  // ---- Random services -------------------------------------------------
+  SmartIF<IRndmGenSvc> m_randSvc;
+  mutable Rndm::Numbers m_gauss_u;  // smear along surface u (local y)
+  mutable Rndm::Numbers m_gauss_v;  // smear along surface v (local z)
+  mutable Rndm::Numbers m_gauss_t;  // smear time if tResolution > 0
+  mutable Rndm::Numbers m_flat;
+};

--- a/MUONdigi/src/MUONDigitizer.cpp
+++ b/MUONdigi/src/MUONDigitizer.cpp
@@ -257,7 +257,7 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
 
       // ---- Optional: project smeared digi onto the actual sensitive surface
       // when it falls outside the chamber's surface bounds.
-      if (m_forceHitsOntoSurface && m_surfMap) {
+      if (m_forceHitsOntoSurface) {
         auto it = m_surfMap->find(seedCellID);
         if (it != m_surfMap->end()) {
           const dd4hep::rec::ISurface* surf = it->second;

--- a/MUONdigi/src/MUONDigitizer.cpp
+++ b/MUONdigi/src/MUONDigitizer.cpp
@@ -1,0 +1,353 @@
+#include "MUONDigitizer.h"
+
+DECLARE_COMPONENT(MUONDigitizer)
+
+namespace {
+// One readout cell that received at least one SimHit, plus the list of
+// SimHits that contributed to it.
+struct FiredCell {
+  int                                   yIndex;  // signed strip index in y
+  int                                   zIndex;  // signed strip index in z
+  double                                energy;  // sum of EDep over contributing SimHits
+  dd4hep::DDSegmentation::CellID        cellID;  // full cellID (used for the local transform)
+  std::vector<edm4hep::SimTrackerHit>   simHits; // contributing SimHits
+};
+// 8-neighbour adjacency on the (y,z) strip grid.
+bool areAdjacent(const FiredCell& a, const FiredCell& b) {
+  const int deltaY = std::abs(a.yIndex - b.yIndex);
+  const int deltaZ = std::abs(a.zIndex - b.zIndex);
+  return deltaY <= 1 && deltaZ <= 1 && (deltaY + deltaZ) > 0;
+}
+}
+
+MUONDigitizer::MUONDigitizer(const std::string& aName, ISvcLocator* aSvcLoc)
+    : Gaudi::Algorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "MUONDigitizer") {
+  declareProperty("inputSimHits", m_input_sim_hits, "Input SimTrackerHit collection");
+  declareProperty("outputDigiHits", m_output_digi_hits, "Output digitised hit collection");
+  declareProperty("outputSimDigiLink", m_output_sim_digi_link,
+                  "Link between digi cluster and each contributing SimHit");
+}
+
+MUONDigitizer::~MUONDigitizer() = default;
+
+StatusCode MUONDigitizer::initialize() {
+  m_randSvc = service("RndmGenSvc", false);
+  if (!m_randSvc) {
+    error() << "Couldn't get RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  if (m_gauss_u.initialize(m_randSvc, Rndm::Gauss(0., m_u_resolution)).isFailure() ||
+      m_gauss_v.initialize(m_randSvc, Rndm::Gauss(0., m_v_resolution)).isFailure() ||
+      m_flat.initialize(m_randSvc, Rndm::Flat(0., 1.)).isFailure()) {
+    error() << "Couldn't initialize spatial-smearing RNGs!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  // Optional time smearing
+  if (m_t_resolution > 0.f) {
+    if (m_gauss_t.initialize(m_randSvc, Rndm::Gauss(0., m_t_resolution)).isFailure()) {
+      error() << "Couldn't initialize time-smearing RNG!" << endmsg;
+      return StatusCode::FAILURE;
+    }
+  }
+
+  // check if readout exists
+  if (m_geoSvc->getDetector()->readouts().find(m_readoutName) == m_geoSvc->getDetector()->readouts().end()) {
+    error() << "Readout <<" << m_readoutName << ">> does not exist." << endmsg;
+    return StatusCode::FAILURE;
+  }
+  m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
+  m_volman  = m_geoSvc->getDetector()->volumeManager();
+
+  //check: the readout must carry a layer field
+  if (m_decoder->fieldDescription().find("layer") == std::string::npos) {
+    error() << "Readout " << m_readoutName << " does not contain a 'layer' id!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  // check surface map 
+  if (m_forceHitsOntoSurface) {
+    auto* theDetector = m_geoSvc->getDetector();
+    auto* surfMan     = theDetector->extension<dd4hep::rec::SurfaceManager>();
+    if (!surfMan) {
+      error() << "No SurfaceManager extension available for the detector" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    dd4hep::DetElement det = theDetector->detector(m_detectorName);
+    m_surfMap = surfMan->map(det.name());
+    if (!m_surfMap) {
+      error() << "Could not find surface map for detector '" << m_detectorName << "'" << endmsg;
+      return StatusCode::FAILURE;
+    }
+  }
+
+  if (m_maxClusterSize < 1u) {
+    error() << "maxClusterSize must be >= 1 (got " << m_maxClusterSize << ")" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  info() << "MUONDigitizer initialised:"
+         << " timeWindow=" << m_timeWindow << " ns,"
+         << " maxClusterSize=" << m_maxClusterSize << " strips/view (8-neighbour),"
+         << " efficiency=" << m_efficiency
+         << ", time smearing=" << (m_t_resolution > 0.f ? std::to_string(m_t_resolution) + " ns" : std::string("OFF"))
+         << ", forceHitsOntoSurface=" << (m_forceHitsOntoSurface.value() ? "ON" : "OFF")
+         << endmsg;
+  return StatusCode::SUCCESS;
+}
+
+StatusCode MUONDigitizer::finalize() { return StatusCode::SUCCESS; }
+
+StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
+  const auto* sim_hits = m_input_sim_hits.get();
+  auto*       digi_hits = m_output_digi_hits.createAndPut();
+  auto*       links = m_output_sim_digi_link.createAndPut();
+  auto*       diffX = m_simDigiDifferenceX.createAndPut();
+  auto*       diffY = m_simDigiDifferenceY.createAndPut();
+  auto*       diffZ = m_simDigiDifferenceZ.createAndPut();
+  auto*       clusterSizesY = m_clusterSizeY.createAndPut();
+  auto*       clusterSizesZ = m_clusterSizeZ.createAndPut();
+
+  debug() << "Event " << ctx.evt() << ": " << sim_hits->size() << " input SimHits" << endmsg;
+
+  // -------------------------------------------------------------------------
+  // Step 1. Group SimHits by cellWindow = (chamberID, timeWindow).
+  // "chamberID" = cellID with the y and z strip fields zeroed,
+  // "timeWindow" = floor(time / m_timeWindow); SimHits in the same chamber
+  // within the same 25 ns window are candidates to be merged into a cluster.
+  // -------------------------------------------------------------------------
+  using CellWindow = std::pair<std::uint64_t, std::int64_t>;
+  std::map<CellWindow, std::vector<FiredCell>> cellWindows;
+
+  for (const auto& sim : *sim_hits) {
+    const auto cellID = sim.getCellID();
+    const int  yIdx   = m_decoder->get(cellID, "y");
+    const int  zIdx   = m_decoder->get(cellID, "z");
+
+    // Build the chamber ID: same cellID, but with y and z set to 0.
+    dd4hep::DDSegmentation::CellID chamberID = cellID;
+    m_decoder->set(chamberID, "y", 0);
+    m_decoder->set(chamberID, "z", 0);
+
+    const auto       tWindow    = static_cast<std::int64_t>(std::floor(sim.getTime() / m_timeWindow));
+    const CellWindow cellWindow{chamberID, tWindow};
+
+    auto& cells = cellWindows[cellWindow];
+    auto  it    = std::find_if(cells.begin(), cells.end(), [&](const FiredCell& c) {
+      return c.yIndex == yIdx && c.zIndex == zIdx;
+    });
+    if (it == cells.end()) {
+      cells.push_back({yIdx, zIdx, sim.getEDep(), cellID, {sim}});
+    } else {
+      it->energy += sim.getEDep();
+      it->simHits.push_back(sim);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2. For each cellWindow, run seeded 8-neighbour clustering.
+  // A cluster may grow as long as the number of distinct Y-strip indices AND
+  // the number of distinct Z-strip indices it covers stay <= maxClusterSize.
+  // Emit one digi hit per cluster.
+  // -------------------------------------------------------------------------
+  for (auto& [cellWindow, cells] : cellWindows) {
+    std::vector<bool> used(cells.size(), false);
+
+    // We always pick the next seed as the highest-energy still-unused cell.
+    while (true) {
+      int    seedIdx = -1;
+      double seedE   = -1.0;
+      for (std::size_t i = 0; i < cells.size(); ++i) {
+        if (!used[i] && cells[i].energy > seedE) {
+          seedE   = cells[i].energy;
+          seedIdx = static_cast<int>(i);
+        }
+      }
+      if (seedIdx < 0) break;  // no unused cells left in this cellWindow
+
+      std::vector<std::size_t> cluster = {static_cast<std::size_t>(seedIdx)};
+      used[seedIdx] = true;
+
+      // Track distinct Y- and Z-strip indices currently in the cluster.
+      std::set<int> yUsed{cells[seedIdx].yIndex};
+      std::set<int> zUsed{cells[seedIdx].zIndex};
+
+      // Grow by repeatedly attaching the highest-energy fired cell that is
+      // 8-neighbour-adjacent and that does not push either view beyond
+      // maxClusterSize distinct strips.
+      while (true) {
+        int    bestIdx = -1;
+        double bestE   = -1.0;
+        for (std::size_t i = 0; i < cells.size(); ++i) {
+          if (used[i]) continue;
+          bool adjacent = false;
+          for (std::size_t j : cluster) {
+            if (areAdjacent(cells[i], cells[j])) { adjacent = true; break; }
+          }
+          if (!adjacent) continue;
+
+          const std::size_t newY = yUsed.count(cells[i].yIndex) ? yUsed.size() : yUsed.size() + 1;
+          const std::size_t newZ = zUsed.count(cells[i].zIndex) ? zUsed.size() : zUsed.size() + 1;
+          if (newY > m_maxClusterSize || newZ > m_maxClusterSize) continue;
+
+          if (cells[i].energy > bestE) {
+            bestE   = cells[i].energy;
+            bestIdx = static_cast<int>(i);
+          }
+        }
+        if (bestIdx < 0) break;
+        cluster.push_back(static_cast<std::size_t>(bestIdx));
+        used[bestIdx] = true;
+        yUsed.insert(cells[bestIdx].yIndex);
+        zUsed.insert(cells[bestIdx].zIndex);
+      }
+
+      // ---- Apply per-cluster efficiency ---------------------------------
+      if (m_flat.shoot() > m_efficiency) {
+        continue;
+      }
+
+      // ---- Energy-weighted centroid of contributing SimHits (mm) --------
+      double totalEnergy      = 0.0;
+      double centroidGlobalX  = 0.0;
+      double centroidGlobalY  = 0.0;
+      double centroidGlobalZ  = 0.0;
+      for (std::size_t idx : cluster) {
+        for (const auto& simHit : cells[idx].simHits) {
+          const double eDep = simHit.getEDep();
+          centroidGlobalX += simHit.getPosition().x * eDep;
+          centroidGlobalY += simHit.getPosition().y * eDep;
+          centroidGlobalZ += simHit.getPosition().z * eDep;
+          totalEnergy     += eDep;
+        }
+      }
+      if (totalEnergy <= 0.0) {
+        // Fallback: just use the seed cell's first SimHit position.
+        const auto& simHit = cells[seedIdx].simHits.front();
+        centroidGlobalX = simHit.getPosition().x;
+        centroidGlobalY = simHit.getPosition().y;
+        centroidGlobalZ = simHit.getPosition().z;
+        totalEnergy     = std::max(totalEnergy, 0.0);
+      } else {
+        centroidGlobalX /= totalEnergy;
+        centroidGlobalY /= totalEnergy;
+        centroidGlobalZ /= totalEnergy;
+      }
+
+      // ---- Gaussian smear in the local frame of the seed cell -----------
+      const auto& seedCellID = cells[seedIdx].cellID;
+      const auto  placement  = m_volman.lookupVolumePlacement(seedCellID);
+      const auto& xform      = placement.matrix();
+
+      double simGlobalPos_cm[3] = {centroidGlobalX * dd4hep::mm,
+                               centroidGlobalY * dd4hep::mm,
+                               centroidGlobalZ * dd4hep::mm};
+      double simLocalPos_cm[3]  = {0., 0., 0.};
+      xform.MasterToLocal(simGlobalPos_cm, simLocalPos_cm);
+
+      const double smearedLocalPos_cm[3] = {
+          0.,
+          simLocalPos_cm[1] + m_gauss_u.shoot() * dd4hep::mm,
+          simLocalPos_cm[2] + m_gauss_v.shoot() * dd4hep::mm};
+
+      double digiGlobalPos_cm[3] = {0., 0., 0.};
+      xform.LocalToMaster(smearedLocalPos_cm, digiGlobalPos_cm);
+
+      // ---- Optional: project smeared digi onto the actual sensitive surface
+      // when it falls outside the chamber's surface bounds.
+      if (m_forceHitsOntoSurface && m_surfMap) {
+        auto it = m_surfMap->find(seedCellID);
+        if (it != m_surfMap->end()) {
+          const dd4hep::rec::ISurface* surf = it->second;
+          dd4hep::rec::Vector3D smearedGlobal(digiGlobalPos_cm[0], digiGlobalPos_cm[1], digiGlobalPos_cm[2]);
+          if (!surf->insideBounds(smearedGlobal)) {
+            const dd4hep::rec::Vector2D lv     = surf->globalToLocal(smearedGlobal);
+            const dd4hep::rec::Vector3D onSurf = surf->localToGlobal(lv);
+            debug() << "  smeared hit fell outside surface bounds (distance "
+                    << surf->distance(smearedGlobal) / dd4hep::mm << " mm); projecting back" << endmsg;
+            digiGlobalPos_cm[0] = onSurf.x();
+            digiGlobalPos_cm[1] = onSurf.y();
+            digiGlobalPos_cm[2] = onSurf.z();
+          }
+        }
+      }
+
+      // ---- Surface u/v axes in global, from the chamber rotation --------
+      const double uLocal[3] = {0., 1., 0.};
+      const double vLocal[3] = {0., 0., 1.};
+      double uGlobal[3], vGlobal[3];
+      xform.LocalToMasterVect(uLocal, uGlobal);
+      xform.LocalToMasterVect(vLocal, vGlobal);
+
+      const float uDir[2] = {static_cast<float>(std::acos(uGlobal[2])),
+                             static_cast<float>(std::atan2(uGlobal[1], uGlobal[0]))};
+      const float vDir[2] = {static_cast<float>(std::acos(vGlobal[2])),
+                             static_cast<float>(std::atan2(vGlobal[1], vGlobal[0]))};
+
+      // ---- Earliest contributing SimHit time -> leading-edge hit time ---
+      float hitTime = std::numeric_limits<float>::infinity();
+      for (std::size_t idx : cluster) {
+        for (const auto& simHit : cells[idx].simHits) {
+          if (simHit.getTime() < hitTime) hitTime = simHit.getTime();
+        }
+      }
+      if (m_t_resolution > 0.f) {
+        hitTime += static_cast<float>(m_gauss_t.shoot());
+      }
+
+      // ---- Emit digi hit ------------------------------------------------
+      auto digi = digi_hits->create();
+      digi.setPosition({digiGlobalPos_cm[0] / dd4hep::mm,
+                        digiGlobalPos_cm[1] / dd4hep::mm,
+                        digiGlobalPos_cm[2] / dd4hep::mm});
+      digi.setCellID(seedCellID);
+      digi.setTime(hitTime);
+      digi.setEDep(totalEnergy);
+      digi.setU(uDir);
+      digi.setV(vDir);
+      digi.setDu(m_u_resolution);
+      digi.setDv(m_v_resolution);
+
+      // One link per contributing SimHit -> this digi hit.
+      std::size_t nSimHits = 0;
+      for (std::size_t idx : cluster) {
+        for (const auto& simHit : cells[idx].simHits) {
+          auto link = links->create();
+          link.setFrom(digi);
+          link.setTo(simHit);
+          ++nSimHits;
+        }
+      }
+
+      if (msgLevel(MSG::DEBUG)) {
+        debug() << "  cluster: cells=" << cluster.size()
+                << " (Y=" << yUsed.size() << ", Z=" << zUsed.size() << "),"
+                << " SimHits=" << nSimHits << ","
+                << " EDep=" << totalEnergy
+                << ", pos=(" << digiGlobalPos_cm[0] / dd4hep::mm
+                << ", "      << digiGlobalPos_cm[1] / dd4hep::mm
+                << ", "      << digiGlobalPos_cm[2] / dd4hep::mm << ") mm,"
+                << " t="     << hitTime << " ns" << endmsg;
+      }
+
+      // ---- Validation outputs ------------------------------------------
+      const double residualX = (digiGlobalPos_cm[0] - simGlobalPos_cm[0]) / dd4hep::mm;
+      const double residualY = (digiGlobalPos_cm[1] - simGlobalPos_cm[1]) / dd4hep::mm;
+      const double residualZ = (digiGlobalPos_cm[2] - simGlobalPos_cm[2]) / dd4hep::mm;
+      diffX->push_back(residualX);
+      diffY->push_back(residualY);
+      diffZ->push_back(residualZ);
+      clusterSizesY->push_back(static_cast<int>(yUsed.size()));
+      clusterSizesZ->push_back(static_cast<int>(zUsed.size()));
+    }
+  }
+
+  debug() << "Event " << ctx.evt() << ": " << digi_hits->size() << " output digi clusters" << endmsg;
+
+  // Per-event heartbeat (INFO). Emit every printFrequency events; 0 disables.
+  if (m_printFrequency > 0 && (ctx.evt() % m_printFrequency == 0)) {
+    info() << "Event " << ctx.evt() << ": " << sim_hits->size() << " SimHits -> "
+           << digi_hits->size() << " digi clusters" << endmsg;
+  }
+
+  return StatusCode::SUCCESS;
+}

--- a/MUONdigi/src/MUONDigitizer.cpp
+++ b/MUONdigi/src/MUONDigitizer.cpp
@@ -6,11 +6,11 @@ namespace {
 // One readout cell that received at least one SimHit, plus the list of
 // SimHits that contributed to it.
 struct FiredCell {
-  int                                   yIndex;  // signed strip index in y
-  int                                   zIndex;  // signed strip index in z
-  double                                energy;  // sum of EDep over contributing SimHits
-  dd4hep::DDSegmentation::CellID        cellID;  // full cellID (used for the local transform)
-  std::vector<edm4hep::SimTrackerHit>   simHits; // contributing SimHits
+  int yIndex;                                  // signed strip index in y
+  int zIndex;                                  // signed strip index in z
+  double energy;                               // sum of EDep over contributing SimHits
+  dd4hep::DDSegmentation::CellID cellID;       // full cellID (used for the local transform)
+  std::vector<edm4hep::SimTrackerHit> simHits; // contributing SimHits
 };
 // 8-neighbour adjacency on the (y,z) strip grid.
 bool areAdjacent(const FiredCell& a, const FiredCell& b) {
@@ -18,7 +18,7 @@ bool areAdjacent(const FiredCell& a, const FiredCell& b) {
   const int deltaZ = std::abs(a.zIndex - b.zIndex);
   return deltaY <= 1 && deltaZ <= 1 && (deltaY + deltaZ) > 0;
 }
-}
+} // namespace
 
 MUONDigitizer::MUONDigitizer(const std::string& aName, ISvcLocator* aSvcLoc)
     : Gaudi::Algorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "MUONDigitizer") {
@@ -56,18 +56,18 @@ StatusCode MUONDigitizer::initialize() {
     return StatusCode::FAILURE;
   }
   m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
-  m_volman  = m_geoSvc->getDetector()->volumeManager();
+  m_volman = m_geoSvc->getDetector()->volumeManager();
 
-  //check: the readout must carry a layer field
+  // check: the readout must carry a layer field
   if (m_decoder->fieldDescription().find("layer") == std::string::npos) {
     error() << "Readout " << m_readoutName << " does not contain a 'layer' id!" << endmsg;
     return StatusCode::FAILURE;
   }
 
-  // check surface map 
+  // check surface map
   if (m_forceHitsOntoSurface) {
     auto* theDetector = m_geoSvc->getDetector();
-    auto* surfMan     = theDetector->extension<dd4hep::rec::SurfaceManager>();
+    auto* surfMan = theDetector->extension<dd4hep::rec::SurfaceManager>();
     if (!surfMan) {
       error() << "No SurfaceManager extension available for the detector" << endmsg;
       return StatusCode::FAILURE;
@@ -90,8 +90,7 @@ StatusCode MUONDigitizer::initialize() {
          << " maxClusterSize=" << m_maxClusterSize << " strips/view (8-neighbour),"
          << " efficiency=" << m_efficiency
          << ", time smearing=" << (m_t_resolution > 0.f ? std::to_string(m_t_resolution) + " ns" : std::string("OFF"))
-         << ", forceHitsOntoSurface=" << (m_forceHitsOntoSurface.value() ? "ON" : "OFF")
-         << endmsg;
+         << ", forceHitsOntoSurface=" << (m_forceHitsOntoSurface.value() ? "ON" : "OFF") << endmsg;
   return StatusCode::SUCCESS;
 }
 
@@ -99,13 +98,13 @@ StatusCode MUONDigitizer::finalize() { return StatusCode::SUCCESS; }
 
 StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
   const auto* sim_hits = m_input_sim_hits.get();
-  auto*       digi_hits = m_output_digi_hits.createAndPut();
-  auto*       links = m_output_sim_digi_link.createAndPut();
-  auto*       diffX = m_simDigiDifferenceX.createAndPut();
-  auto*       diffY = m_simDigiDifferenceY.createAndPut();
-  auto*       diffZ = m_simDigiDifferenceZ.createAndPut();
-  auto*       clusterSizesY = m_clusterSizeY.createAndPut();
-  auto*       clusterSizesZ = m_clusterSizeZ.createAndPut();
+  auto* digi_hits = m_output_digi_hits.createAndPut();
+  auto* links = m_output_sim_digi_link.createAndPut();
+  auto* diffX = m_simDigiDifferenceX.createAndPut();
+  auto* diffY = m_simDigiDifferenceY.createAndPut();
+  auto* diffZ = m_simDigiDifferenceZ.createAndPut();
+  auto* clusterSizesY = m_clusterSizeY.createAndPut();
+  auto* clusterSizesZ = m_clusterSizeZ.createAndPut();
 
   debug() << "Event " << ctx.evt() << ": " << sim_hits->size() << " input SimHits" << endmsg;
 
@@ -120,21 +119,20 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
 
   for (const auto& sim : *sim_hits) {
     const auto cellID = sim.getCellID();
-    const int  yIdx   = m_decoder->get(cellID, "y");
-    const int  zIdx   = m_decoder->get(cellID, "z");
+    const int yIdx = m_decoder->get(cellID, "y");
+    const int zIdx = m_decoder->get(cellID, "z");
 
     // Build the chamber ID: same cellID, but with y and z set to 0.
     dd4hep::DDSegmentation::CellID chamberID = cellID;
     m_decoder->set(chamberID, "y", 0);
     m_decoder->set(chamberID, "z", 0);
 
-    const auto       tWindow    = static_cast<std::int64_t>(std::floor(sim.getTime() / m_timeWindow));
+    const auto tWindow = static_cast<std::int64_t>(std::floor(sim.getTime() / m_timeWindow));
     const CellWindow cellWindow{chamberID, tWindow};
 
     auto& cells = cellWindows[cellWindow];
-    auto  it    = std::find_if(cells.begin(), cells.end(), [&](const FiredCell& c) {
-      return c.yIndex == yIdx && c.zIndex == zIdx;
-    });
+    auto it = std::find_if(cells.begin(), cells.end(),
+                           [&](const FiredCell& c) { return c.yIndex == yIdx && c.zIndex == zIdx; });
     if (it == cells.end()) {
       cells.push_back({yIdx, zIdx, sim.getEDep(), cellID, {sim}});
     } else {
@@ -154,15 +152,16 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
 
     // We always pick the next seed as the highest-energy still-unused cell.
     while (true) {
-      int    seedIdx = -1;
-      double seedE   = -1.0;
+      int seedIdx = -1;
+      double seedE = -1.0;
       for (std::size_t i = 0; i < cells.size(); ++i) {
         if (!used[i] && cells[i].energy > seedE) {
-          seedE   = cells[i].energy;
+          seedE = cells[i].energy;
           seedIdx = static_cast<int>(i);
         }
       }
-      if (seedIdx < 0) break;  // no unused cells left in this cellWindow
+      if (seedIdx < 0)
+        break; // no unused cells left in this cellWindow
 
       std::vector<std::size_t> cluster = {static_cast<std::size_t>(seedIdx)};
       used[seedIdx] = true;
@@ -175,26 +174,33 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
       // 8-neighbour-adjacent and that does not push either view beyond
       // maxClusterSize distinct strips.
       while (true) {
-        int    bestIdx = -1;
-        double bestE   = -1.0;
+        int bestIdx = -1;
+        double bestE = -1.0;
         for (std::size_t i = 0; i < cells.size(); ++i) {
-          if (used[i]) continue;
+          if (used[i])
+            continue;
           bool adjacent = false;
           for (std::size_t j : cluster) {
-            if (areAdjacent(cells[i], cells[j])) { adjacent = true; break; }
+            if (areAdjacent(cells[i], cells[j])) {
+              adjacent = true;
+              break;
+            }
           }
-          if (!adjacent) continue;
+          if (!adjacent)
+            continue;
 
           const std::size_t newY = yUsed.count(cells[i].yIndex) ? yUsed.size() : yUsed.size() + 1;
           const std::size_t newZ = zUsed.count(cells[i].zIndex) ? zUsed.size() : zUsed.size() + 1;
-          if (newY > m_maxClusterSize || newZ > m_maxClusterSize) continue;
+          if (newY > m_maxClusterSize || newZ > m_maxClusterSize)
+            continue;
 
           if (cells[i].energy > bestE) {
-            bestE   = cells[i].energy;
+            bestE = cells[i].energy;
             bestIdx = static_cast<int>(i);
           }
         }
-        if (bestIdx < 0) break;
+        if (bestIdx < 0)
+          break;
         cluster.push_back(static_cast<std::size_t>(bestIdx));
         used[bestIdx] = true;
         yUsed.insert(cells[bestIdx].yIndex);
@@ -207,17 +213,17 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
       }
 
       // ---- Energy-weighted centroid of contributing SimHits (mm) --------
-      double totalEnergy      = 0.0;
-      double centroidGlobalX  = 0.0;
-      double centroidGlobalY  = 0.0;
-      double centroidGlobalZ  = 0.0;
+      double totalEnergy = 0.0;
+      double centroidGlobalX = 0.0;
+      double centroidGlobalY = 0.0;
+      double centroidGlobalZ = 0.0;
       for (std::size_t idx : cluster) {
         for (const auto& simHit : cells[idx].simHits) {
           const double eDep = simHit.getEDep();
           centroidGlobalX += simHit.getPosition().x * eDep;
           centroidGlobalY += simHit.getPosition().y * eDep;
           centroidGlobalZ += simHit.getPosition().z * eDep;
-          totalEnergy     += eDep;
+          totalEnergy += eDep;
         }
       }
       if (totalEnergy <= 0.0) {
@@ -226,7 +232,7 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
         centroidGlobalX = simHit.getPosition().x;
         centroidGlobalY = simHit.getPosition().y;
         centroidGlobalZ = simHit.getPosition().z;
-        totalEnergy     = std::max(totalEnergy, 0.0);
+        totalEnergy = std::max(totalEnergy, 0.0);
       } else {
         centroidGlobalX /= totalEnergy;
         centroidGlobalY /= totalEnergy;
@@ -235,19 +241,16 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
 
       // ---- Gaussian smear in the local frame of the seed cell -----------
       const auto& seedCellID = cells[seedIdx].cellID;
-      const auto  placement  = m_volman.lookupVolumePlacement(seedCellID);
-      const auto& xform      = placement.matrix();
+      const auto placement = m_volman.lookupVolumePlacement(seedCellID);
+      const auto& xform = placement.matrix();
 
-      double simGlobalPos_cm[3] = {centroidGlobalX * dd4hep::mm,
-                               centroidGlobalY * dd4hep::mm,
-                               centroidGlobalZ * dd4hep::mm};
-      double simLocalPos_cm[3]  = {0., 0., 0.};
+      double simGlobalPos_cm[3] = {centroidGlobalX * dd4hep::mm, centroidGlobalY * dd4hep::mm,
+                                   centroidGlobalZ * dd4hep::mm};
+      double simLocalPos_cm[3] = {0., 0., 0.};
       xform.MasterToLocal(simGlobalPos_cm, simLocalPos_cm);
 
-      const double smearedLocalPos_cm[3] = {
-          0.,
-          simLocalPos_cm[1] + m_gauss_u.shoot() * dd4hep::mm,
-          simLocalPos_cm[2] + m_gauss_v.shoot() * dd4hep::mm};
+      const double smearedLocalPos_cm[3] = {0., simLocalPos_cm[1] + m_gauss_u.shoot() * dd4hep::mm,
+                                            simLocalPos_cm[2] + m_gauss_v.shoot() * dd4hep::mm};
 
       double digiGlobalPos_cm[3] = {0., 0., 0.};
       xform.LocalToMaster(smearedLocalPos_cm, digiGlobalPos_cm);
@@ -260,7 +263,7 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
           const dd4hep::rec::ISurface* surf = it->second;
           dd4hep::rec::Vector3D smearedGlobal(digiGlobalPos_cm[0], digiGlobalPos_cm[1], digiGlobalPos_cm[2]);
           if (!surf->insideBounds(smearedGlobal)) {
-            const dd4hep::rec::Vector2D lv     = surf->globalToLocal(smearedGlobal);
+            const dd4hep::rec::Vector2D lv = surf->globalToLocal(smearedGlobal);
             const dd4hep::rec::Vector3D onSurf = surf->localToGlobal(lv);
             debug() << "  smeared hit fell outside surface bounds (distance "
                     << surf->distance(smearedGlobal) / dd4hep::mm << " mm); projecting back" << endmsg;
@@ -287,7 +290,8 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
       float hitTime = std::numeric_limits<float>::infinity();
       for (std::size_t idx : cluster) {
         for (const auto& simHit : cells[idx].simHits) {
-          if (simHit.getTime() < hitTime) hitTime = simHit.getTime();
+          if (simHit.getTime() < hitTime)
+            hitTime = simHit.getTime();
         }
       }
       if (m_t_resolution > 0.f) {
@@ -296,9 +300,8 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
 
       // ---- Emit digi hit ------------------------------------------------
       auto digi = digi_hits->create();
-      digi.setPosition({digiGlobalPos_cm[0] / dd4hep::mm,
-                        digiGlobalPos_cm[1] / dd4hep::mm,
-                        digiGlobalPos_cm[2] / dd4hep::mm});
+      digi.setPosition(
+          {digiGlobalPos_cm[0] / dd4hep::mm, digiGlobalPos_cm[1] / dd4hep::mm, digiGlobalPos_cm[2] / dd4hep::mm});
       digi.setCellID(seedCellID);
       digi.setTime(hitTime);
       digi.setEDep(totalEnergy);
@@ -319,14 +322,11 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
       }
 
       if (msgLevel(MSG::DEBUG)) {
-        debug() << "  cluster: cells=" << cluster.size()
-                << " (Y=" << yUsed.size() << ", Z=" << zUsed.size() << "),"
+        debug() << "  cluster: cells=" << cluster.size() << " (Y=" << yUsed.size() << ", Z=" << zUsed.size() << "),"
                 << " SimHits=" << nSimHits << ","
-                << " EDep=" << totalEnergy
-                << ", pos=(" << digiGlobalPos_cm[0] / dd4hep::mm
-                << ", "      << digiGlobalPos_cm[1] / dd4hep::mm
-                << ", "      << digiGlobalPos_cm[2] / dd4hep::mm << ") mm,"
-                << " t="     << hitTime << " ns" << endmsg;
+                << " EDep=" << totalEnergy << ", pos=(" << digiGlobalPos_cm[0] / dd4hep::mm << ", "
+                << digiGlobalPos_cm[1] / dd4hep::mm << ", " << digiGlobalPos_cm[2] / dd4hep::mm << ") mm,"
+                << " t=" << hitTime << " ns" << endmsg;
       }
 
       // ---- Validation outputs ------------------------------------------
@@ -345,8 +345,8 @@ StatusCode MUONDigitizer::execute(const EventContext& ctx) const {
 
   // Per-event heartbeat (INFO). Emit every printFrequency events; 0 disables.
   if (m_printFrequency > 0 && (ctx.evt() % m_printFrequency == 0)) {
-    info() << "Event " << ctx.evt() << ": " << sim_hits->size() << " SimHits -> "
-           << digi_hits->size() << " digi clusters" << endmsg;
+    info() << "Event " << ctx.evt() << ": " << sim_hits->size() << " SimHits -> " << digi_hits->size()
+           << " digi clusters" << endmsg;
   }
 
   return StatusCode::SUCCESS;

--- a/MUONdigi/test/runMUONDigitizer.py
+++ b/MUONdigi/test/runMUONDigitizer.py
@@ -1,0 +1,173 @@
+import os, math
+
+from Gaudi.Configuration import *
+
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
+
+podioevent = EventDataSvc("EventDataSvc")
+
+from GaudiKernel.SystemOfUnits import MeV, GeV, tesla
+
+################## Particle gun setup
+momentum = 5            # in GeV
+thetaMin = 0            # degrees
+thetaMax = 180          # degrees
+pdgCode  = 13           # 13 = mu+/-
+magneticField = True
+_pi = 3.14159
+
+################## Muon-system digi parameters (cluster-based, uRWELL)
+detectorName         = "Muon-System"
+uResolution          = 0.4    # mm   surface u (= chamber-local y)
+vResolution          = 0.4    # mm   surface v (= chamber-local z)
+tResolution          = -1.0   # ns   <=0 disables time smearing (digi time = earliest SimHit time)
+efficiency           = 0.98   # per-cluster detection efficiency
+timeWindow           = 25.0   # ns   SimHits within this window go in one cluster
+maxClusterSize       = 3      # max distinct strips per view (Y, Z) inside one cluster
+forceHitsOntoSurface = True   # if True, project smeared digi back onto the chamber surface if it lands outside
+printFrequency       = 1      # INFO line every N events (set 0 to silence, 100 for production)
+
+from Configurables import GenAlg
+
+genAlg = GenAlg()
+from Configurables import MomentumRangeParticleGun
+
+pgun = MomentumRangeParticleGun("ParticleGun_Muon")
+pgun.PdgCodes    = [pdgCode]
+pgun.MomentumMin = momentum * GeV
+pgun.MomentumMax = momentum * GeV
+pgun.PhiMin      = 0
+pgun.PhiMax      = 2 * _pi
+pgun.ThetaMin    = thetaMin * _pi / 180.0
+pgun.ThetaMax    = thetaMax * _pi / 180.0
+genAlg.SignalProvider = pgun
+genAlg.hepmc.Path = "hepmc"
+
+from Configurables import HepMCToEDMConverter
+
+hepmc_converter = HepMCToEDMConverter()
+hepmc_converter.hepmc.Path = "hepmc"
+genParticlesOutputName = "genParticles"
+hepmc_converter.GenParticles.Path = genParticlesOutputName
+hepmc_converter.hepmcStatusList = []
+
+################## Simulation setup
+# Detector geometry
+from Configurables import GeoSvc
+
+geoservice = GeoSvc("GeoSvc")
+path_to_detector = os.environ.get("K4GEO", "")
+print("K4GEO =", path_to_detector)
+detectors_to_use = [
+    "FCCee/IDEA/compact/IDEA_o1_v03/IDEA_4L_50cm.xml",
+]
+geoservice.detectors = [os.path.join(path_to_detector, _det) for _det in detectors_to_use]
+geoservice.OutputLevel = INFO
+
+# Geant4
+from Configurables import (
+    SimG4FullSimActions,
+    SimG4Alg,
+    SimG4PrimariesFromEdmTool,
+    SimG4SaveParticleHistory,
+)
+
+actions = SimG4FullSimActions()
+
+# Magnetic field
+from Configurables import SimG4ConstantMagneticFieldTool
+
+field = SimG4ConstantMagneticFieldTool(
+    "SimG4ConstantMagneticFieldTool",
+    FieldComponentZ=-2 * tesla,
+    FieldOn=magneticField,
+    IntegratorStepper="ClassicalRK4",
+)
+
+from Configurables import SimG4Svc
+
+geantservice = SimG4Svc(
+    "SimG4Svc",
+    detector="SimG4DD4hepDetector",
+    physicslist="SimG4FtfpBert",
+    magneticField=field,
+)
+geantservice.randomNumbersFromGaudi = False
+geantservice.seedValue = 4242
+geantservice.g4PreInitCommands += ["/run/setCut 0.1 mm"]
+
+# Geant4 algorithm
+particle_converter = SimG4PrimariesFromEdmTool("EdmConverter")
+particle_converter.GenParticles.Path = genParticlesOutputName
+
+from Configurables import SimG4SaveTrackerHits
+
+SimG4SaveMuonHits = SimG4SaveTrackerHits(
+    "SimG4SaveMuonHits", readoutName="MuonSystemCollection"
+)
+SimG4SaveMuonHits.SimTrackHits.Path = "MuonSystemCollection"
+
+geantsim = SimG4Alg(
+    "SimG4Alg",
+    outputs=[SimG4SaveMuonHits],
+    eventProvider=particle_converter,
+    OutputLevel=INFO,
+)
+
+# Digitize muon-system hits — cluster-based
+from Configurables import MUONDigitizer
+
+muon_digitizer = MUONDigitizer(
+    "MUONDigitizer",
+    inputSimHits         = SimG4SaveMuonHits.SimTrackHits.Path,
+    outputDigiHits       = "MSTrackerHits",
+    outputSimDigiLink    = "MSTrackerHitRelations",
+    detectorName         = detectorName,
+    readoutName          = "MuonSystemCollection",
+    uResolution          = uResolution,
+    vResolution          = vResolution,
+    tResolution          = tResolution,
+    efficiency           = efficiency,
+    timeWindow           = timeWindow,
+    maxClusterSize       = maxClusterSize,
+    forceHitsOntoSurface = forceHitsOntoSurface,
+    printFrequency       = printFrequency,
+    OutputLevel          = INFO,
+)
+
+################ Output
+iosvc = IOSvc()
+iosvc.Output = (
+    "output_MuonSystemDigi"
+    + "_B" + str(magneticField)
+    + "_pMin_" + str(momentum * 1000) + "_MeV"
+    + "_ThetaMinMax_" + str(thetaMin) + "_" + str(thetaMax)
+    + "_pdgId_" + str(pdgCode)
+    + ".root"
+)
+iosvc.outputCommands = ["keep *"]
+
+# CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+genAlg.AuditExecute          = True
+hepmc_converter.AuditExecute = True
+geantsim.AuditExecute        = True
+muon_digitizer.AuditExecute  = True
+
+ApplicationMgr(
+    TopAlg=[
+        genAlg,
+        hepmc_converter,
+        geantsim,
+        muon_digitizer,
+    ],
+    EvtSel="NONE",
+    EvtMax=10,
+    ExtSvc=[geoservice, podioevent, geantservice, audsvc],
+    StopOnSignal=True,
+)

--- a/MUONdigi/test/runMUONDigitizer.py
+++ b/MUONdigi/test/runMUONDigitizer.py
@@ -10,23 +10,25 @@ podioevent = EventDataSvc("EventDataSvc")
 from GaudiKernel.SystemOfUnits import MeV, GeV, tesla
 
 ################## Particle gun setup
-momentum = 5            # in GeV
-thetaMin = 0            # degrees
-thetaMax = 180          # degrees
-pdgCode  = 13           # 13 = mu+/-
+momentum = 5  # in GeV
+thetaMin = 0  # degrees
+thetaMax = 180  # degrees
+pdgCode = 13  # 13 = mu+/-
 magneticField = True
 _pi = 3.14159
 
 ################## Muon-system digi parameters (cluster-based, uRWELL)
-detectorName         = "Muon-System"
-uResolution          = 0.4    # mm   surface u (= chamber-local y)
-vResolution          = 0.4    # mm   surface v (= chamber-local z)
-tResolution          = -1.0   # ns   <=0 disables time smearing (digi time = earliest SimHit time)
-efficiency           = 0.98   # per-cluster detection efficiency
-timeWindow           = 25.0   # ns   SimHits within this window go in one cluster
-maxClusterSize       = 3      # max distinct strips per view (Y, Z) inside one cluster
-forceHitsOntoSurface = True   # if True, project smeared digi back onto the chamber surface if it lands outside
-printFrequency       = 1      # INFO line every N events (set 0 to silence, 100 for production)
+detectorName = "Muon-System"
+uResolution = 0.4  # mm   surface u (= chamber-local y)
+vResolution = 0.4  # mm   surface v (= chamber-local z)
+tResolution = -1.0  # ns   <=0 disables time smearing (digi time = earliest SimHit time)
+efficiency = 0.98  # per-cluster detection efficiency
+timeWindow = 25.0  # ns   SimHits within this window go in one cluster
+maxClusterSize = 3  # max distinct strips per view (Y, Z) inside one cluster
+forceHitsOntoSurface = (
+    True  # if True, project smeared digi back onto the chamber surface if it lands outside
+)
+printFrequency = 1  # INFO line every N events (set 0 to silence, 100 for production)
 
 from Configurables import GenAlg
 
@@ -34,13 +36,13 @@ genAlg = GenAlg()
 from Configurables import MomentumRangeParticleGun
 
 pgun = MomentumRangeParticleGun("ParticleGun_Muon")
-pgun.PdgCodes    = [pdgCode]
+pgun.PdgCodes = [pdgCode]
 pgun.MomentumMin = momentum * GeV
 pgun.MomentumMax = momentum * GeV
-pgun.PhiMin      = 0
-pgun.PhiMax      = 2 * _pi
-pgun.ThetaMin    = thetaMin * _pi / 180.0
-pgun.ThetaMax    = thetaMax * _pi / 180.0
+pgun.PhiMin = 0
+pgun.PhiMax = 2 * _pi
+pgun.ThetaMin = thetaMin * _pi / 180.0
+pgun.ThetaMax = thetaMax * _pi / 180.0
 genAlg.SignalProvider = pgun
 genAlg.hepmc.Path = "hepmc"
 
@@ -103,9 +105,7 @@ particle_converter.GenParticles.Path = genParticlesOutputName
 
 from Configurables import SimG4SaveTrackerHits
 
-SimG4SaveMuonHits = SimG4SaveTrackerHits(
-    "SimG4SaveMuonHits", readoutName="MuonSystemCollection"
-)
+SimG4SaveMuonHits = SimG4SaveTrackerHits("SimG4SaveMuonHits", readoutName="MuonSystemCollection")
 SimG4SaveMuonHits.SimTrackHits.Path = "MuonSystemCollection"
 
 geantsim = SimG4Alg(
@@ -120,30 +120,37 @@ from Configurables import MUONDigitizer
 
 muon_digitizer = MUONDigitizer(
     "MUONDigitizer",
-    inputSimHits         = SimG4SaveMuonHits.SimTrackHits.Path,
-    outputDigiHits       = "MSTrackerHits",
-    outputSimDigiLink    = "MSTrackerHitRelations",
-    detectorName         = detectorName,
-    readoutName          = "MuonSystemCollection",
-    uResolution          = uResolution,
-    vResolution          = vResolution,
-    tResolution          = tResolution,
-    efficiency           = efficiency,
-    timeWindow           = timeWindow,
-    maxClusterSize       = maxClusterSize,
-    forceHitsOntoSurface = forceHitsOntoSurface,
-    printFrequency       = printFrequency,
-    OutputLevel          = INFO,
+    inputSimHits=SimG4SaveMuonHits.SimTrackHits.Path,
+    outputDigiHits="MSTrackerHits",
+    outputSimDigiLink="MSTrackerHitRelations",
+    detectorName=detectorName,
+    readoutName="MuonSystemCollection",
+    uResolution=uResolution,
+    vResolution=vResolution,
+    tResolution=tResolution,
+    efficiency=efficiency,
+    timeWindow=timeWindow,
+    maxClusterSize=maxClusterSize,
+    forceHitsOntoSurface=forceHitsOntoSurface,
+    printFrequency=printFrequency,
+    OutputLevel=INFO,
 )
 
 ################ Output
 iosvc = IOSvc()
 iosvc.Output = (
     "output_MuonSystemDigi"
-    + "_B" + str(magneticField)
-    + "_pMin_" + str(momentum * 1000) + "_MeV"
-    + "_ThetaMinMax_" + str(thetaMin) + "_" + str(thetaMax)
-    + "_pdgId_" + str(pdgCode)
+    + "_B"
+    + str(magneticField)
+    + "_pMin_"
+    + str(momentum * 1000)
+    + "_MeV"
+    + "_ThetaMinMax_"
+    + str(thetaMin)
+    + "_"
+    + str(thetaMax)
+    + "_pdgId_"
+    + str(pdgCode)
     + ".root"
 )
 iosvc.outputCommands = ["keep *"]
@@ -154,10 +161,10 @@ from Configurables import AuditorSvc, ChronoAuditor
 chra = ChronoAuditor()
 audsvc = AuditorSvc()
 audsvc.Auditors = [chra]
-genAlg.AuditExecute          = True
+genAlg.AuditExecute = True
 hepmc_converter.AuditExecute = True
-geantsim.AuditExecute        = True
-muon_digitizer.AuditExecute  = True
+geantsim.AuditExecute = True
+muon_digitizer.AuditExecute = True
 
 ApplicationMgr(
     TopAlg=[

--- a/MUONdigi/test/runMUONDigitizer.py
+++ b/MUONdigi/test/runMUONDigitizer.py
@@ -60,7 +60,7 @@ geoservice = GeoSvc("GeoSvc")
 path_to_detector = os.environ.get("K4GEO", "")
 print("K4GEO =", path_to_detector)
 detectors_to_use = [
-    "FCCee/IDEA/compact/IDEA_o1_v03/IDEA_4L_50cm.xml",
+    "FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml",
 ]
 geoservice.detectors = [os.path.join(path_to_detector, _det) for _det in detectors_to_use]
 geoservice.OutputLevel = INFO


### PR DESCRIPTION
BEGINRELEASENOTES

- Creating a cluster-based digitization algorithm for IDEA Muon-system
- It clusters the simHits located in the same uRWELL chamber within specific cluster-size (number of strips fired by avalanche) into one digiHit, the value we get from test-beam results.
- The goal is to cluster the secondaries (mainly delta-rays) lies within specific radius away from primary into one cluster, and not many separate digiHits.
- The code also doing the same task as DDPlanarDigi for smearing hits positions and time, and applying efficiency filter.
- It was better to have all digi steps of muon-system in one, instead of calling many different algorithms in steering files because of the requirements of specific types of inputs and associations, and to avoid complexity. 
- There's aslo a forcing hits into surface to avoid hit positions outside the chamber surfaces.
- We expect further developments in that MUONDigi for extra digitization  steps in future

ENDRELEASENOTES
