### PR TITLE
Add track merging algorithm based on track parameter compatibility

### DIFF
--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -92,4 +92,9 @@ set_test_env(${test_name})
 set_tests_properties(${test_name} PROPERTIES DEPENDS test_TrackFinder)
 set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/Tracking/test/testTrackFitter")
 
+SET(test_name "test_TrackMerger")
+ADD_TEST(NAME ${test_name} COMMAND python3 test_track_merger.py)
+set_test_env(${test_name})
+set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/Tracking/test/testTrackMerger")
+
 #endif()

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -95,12 +95,21 @@ set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_D
 SET(test_name "test_TrackMerger")
 SET(test_dir "${CMAKE_SOURCE_DIR}/Tracking/test/testTrackMerger")
 
+ADD_TEST(NAME ${test_name}_setup
+  COMMAND python3 test_track_merger.py setup --input input.root)
+set_test_env(${test_name}_setup)
+set_tests_properties(${test_name}_setup PROPERTIES
+  WORKING_DIRECTORY "${test_dir}"
+  FIXTURES_SETUP ${test_name}_input_fixture
+)
+
 ADD_TEST(NAME ${test_name}_run
-  COMMAND python3 test_track_merger.py run --input input.root --output output.root)
+  COMMAND k4run test_track_merger_steer.py --input input.root --output output.root)
 set_test_env(${test_name}_run)
 set_tests_properties(${test_name}_run PROPERTIES
   WORKING_DIRECTORY "${test_dir}"
-  FIXTURES_SETUP ${test_name}_fixture
+  FIXTURES_REQUIRED ${test_name}_input_fixture
+  FIXTURES_SETUP ${test_name}_output_fixture
 )
 
 ADD_TEST(NAME ${test_name}_check
@@ -108,7 +117,6 @@ ADD_TEST(NAME ${test_name}_check
 set_test_env(${test_name}_check)
 set_tests_properties(${test_name}_check PROPERTIES
   WORKING_DIRECTORY "${test_dir}"
-  FIXTURES_REQUIRED ${test_name}_fixture
+  FIXTURES_REQUIRED ${test_name}_output_fixture
 )
-
 #endif()

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -111,11 +111,4 @@ set_tests_properties(${test_name}_check PROPERTIES
   FIXTURES_REQUIRED ${test_name}_fixture
 )
 
-ADD_TEST(NAME ${test_name}_cleanup
-  COMMAND ${CMAKE_COMMAND} -E rm -f input.root output.root)
-set_tests_properties(${test_name}_cleanup PROPERTIES
-  WORKING_DIRECTORY "${test_dir}"
-  FIXTURES_CLEANUP ${test_name}_fixture
-)
-
 #endif()

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -93,8 +93,29 @@ set_tests_properties(${test_name} PROPERTIES DEPENDS test_TrackFinder)
 set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/Tracking/test/testTrackFitter")
 
 SET(test_name "test_TrackMerger")
-ADD_TEST(NAME ${test_name} COMMAND python3 test_track_merger.py)
-set_test_env(${test_name})
-set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/Tracking/test/testTrackMerger")
+SET(test_dir "${CMAKE_SOURCE_DIR}/Tracking/test/testTrackMerger")
+
+ADD_TEST(NAME ${test_name}_run
+  COMMAND python3 test_track_merger.py run --input input.root --output output.root)
+set_test_env(${test_name}_run)
+set_tests_properties(${test_name}_run PROPERTIES
+  WORKING_DIRECTORY "${test_dir}"
+  FIXTURES_SETUP ${test_name}_fixture
+)
+
+ADD_TEST(NAME ${test_name}_check
+  COMMAND python3 test_track_merger.py check --output output.root)
+set_test_env(${test_name}_check)
+set_tests_properties(${test_name}_check PROPERTIES
+  WORKING_DIRECTORY "${test_dir}"
+  FIXTURES_REQUIRED ${test_name}_fixture
+)
+
+ADD_TEST(NAME ${test_name}_cleanup
+  COMMAND ${CMAKE_COMMAND} -E rm -f input.root output.root)
+set_tests_properties(${test_name}_cleanup PROPERTIES
+  WORKING_DIRECTORY "${test_dir}"
+  FIXTURES_CLEANUP ${test_name}_fixture
+)
 
 #endif()

--- a/Tracking/components/TrackMerger.cpp
+++ b/Tracking/components/TrackMerger.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2020-2026 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edm4hep/Track.h"
+#include "edm4hep/TrackCollection.h"
+#include "edm4hep/TrackState.h"
+#include "edm4hep/TrackerHit.h"
+#include "k4FWCore/Transformer.h"
+
+#include "edm4hep/MCParticleCollection.h"
+
+#include <string>
+
+// Type aliases for improved readability
+using TrackColl = edm4hep::TrackCollection;
+using Track = edm4hep::Track;
+using TP = edm4hep::TrackParams;
+using TS = edm4hep::TrackState;
+
+struct TrackMerger final : k4FWCore::Transformer<TrackColl(const TrackColl&, const TrackColl&)> {
+  TrackMerger(const std::string& name, ISvcLocator* svcLoc)
+      : Transformer(name, svcLoc,
+                    {
+                        KeyValue("InputSiTracks", {"SiTracksCT"}),
+                        KeyValue("InputCluTracks", {"ClupatraTracks"}),
+                    },
+                    {KeyValue("OutTracks", {"MyCandidateMergedTracks"})}) {}
+
+  Gaudi::Property<bool> m_greedy{this, "Greedy", true, "If true, each track is used only once."};
+
+  TrackColl operator()(const TrackColl& inSiTracks, const TrackColl& inCluTracks) const override {
+    auto outTracks = TrackColl();
+
+    debug() << "Received SiTracks collection with " << inSiTracks.size() << " tracks" << endmsg;
+    debug() << "Received ClupatraTracks collection with " << inCluTracks.size() << " tracks" << endmsg;
+
+    // 1. Check if both input collections have at least one entry
+    if (inSiTracks.empty() || inCluTracks.empty()) {
+      warning() << "One of the input collections is empty. SiTracks: " << inSiTracks.size()
+                << ", CluTracks: " << inCluTracks.size() << ". Skipping track merging for this event." << endmsg;
+      return outTracks; // Returns empty collection
+    }
+
+    // Flag to ensure each Clupatra track is only merged once
+    std::vector<bool> cluUsed(inCluTracks.size(), false);
+
+    // Loop over Silicon tracks with index for debug output
+    for (size_t iSi = 0; iSi < inSiTracks.size(); iSi++) {
+      const auto trackSi = inSiTracks[iSi];
+      bool matched = false;
+
+      // Explicit index loop for Clupatra tracks to manage 'cluUsed' and debug indexing
+      // LOGIC NOTE: This algorithm accepts the FIRST match found within tolerances.
+      // It does not perform a global chi2 minimization or search for the "best" match.
+      for (size_t iClu = 0; iClu < inCluTracks.size(); iClu++) {
+        if (m_greedy && cluUsed[iClu])
+          continue;
+
+        const auto trackClu = inCluTracks[iClu];
+
+        // compare trackSi and trackClu at their respective track states (Si: last hit (closest to TPC), Clu: first hit
+        // (closest to Si)) to determine if they likely originate from the same particle
+        if (isMatch(trackSi, TS::AtLastHit, trackClu, TS::AtFirstHit)) {
+          debug() << fmt::format("  [MATCH] SiTrack {} matched with CluTrack {}. Creating merged track.", iSi, iClu)
+                  << endmsg;
+
+          auto newTrack = outTracks.create();
+
+          // Combine hits from both sub-detectors
+          for (const auto& hit : trackSi.getTrackerHits())
+            newTrack.addToTrackerHits(hit);
+          for (const auto& hit : trackClu.getTrackerHits())
+            newTrack.addToTrackerHits(hit);
+
+          // Maintain navigation/provenance by linking parent tracks
+          newTrack.addToTracks(trackSi);
+          newTrack.addToTracks(trackClu);
+
+          matched = true;
+          if (m_greedy) {
+            cluUsed[iClu] = true;
+            break; // Exit inner loop: current SiTrack is satisfied
+          }
+        }
+      }
+
+      if (!matched) {
+        debug() << fmt::format("  [INFO] SiTrack {} found no matching Clupatra track within tolerances.", iSi)
+                << endmsg;
+      }
+    }
+
+    debug() << fmt::format("Event processing complete. Created {} merged tracks from {} SiTracks and {} CluTracks.",
+                           outTracks.size(), inSiTracks.size(), inCluTracks.size())
+            << endmsg;
+    return outTracks;
+  }
+
+private:
+  bool isMatch(const edm4hep::Track& t1, int loc1, const edm4hep::Track& t2, int loc2) const {
+    auto ts1 = getTrackState(t1, loc1);
+    auto ts2 = getTrackState(t2, loc2);
+
+    if (!ts1.has_value() || !ts2.has_value()) {
+      // It's common for some tracks to lack specific states; verbose instead of debug to avoid spam
+      warning() << fmt::format("    [SKIP] Missing requested states (Loc1: {}, Loc2: {})", loc1, loc2) << endmsg;
+      return false;
+    }
+
+    // Define matching criteria based on d0 and z0 differences
+    const float d0_diff = std::abs(ts1->D0 - ts2->D0);
+    const float z0_diff = std::abs(ts1->Z0 - ts2->Z0);
+    const bool match = (d0_diff <= 0.5f && z0_diff <= 2.5f);
+
+    debug() << fmt::format("    Comparing Loc {} vs {}: d0_diff={:.4f}, z0_diff={:.4f} -> Match: {}", loc1, loc2,
+                           d0_diff, z0_diff, match)
+            << endmsg;
+
+    return match;
+  }
+
+  std::optional<const TS> getTrackState(const Track& track, const int loc) const {
+    const auto& trackStates = track.getTrackStates();
+
+    if (auto it = std::ranges::find(trackStates, loc, &TS::location); it != trackStates.end()) {
+      return *it;
+    } else {
+      warning() << std::format("No track state at location {} found!", loc) << endmsg;
+      return std::nullopt;
+    }
+  }
+};
+
+DECLARE_COMPONENT(TrackMerger)

--- a/Tracking/components/TrackMerger.cpp
+++ b/Tracking/components/TrackMerger.cpp
@@ -37,77 +37,79 @@ struct TrackMerger final : k4FWCore::Transformer<TrackColl(const TrackColl&, con
   TrackMerger(const std::string& name, ISvcLocator* svcLoc)
       : Transformer(name, svcLoc,
                     {
-                        KeyValue("InputSiTracks", {"SiTracksCT"}),
-                        KeyValue("InputCluTracks", {"ClupatraTracks"}),
+                        KeyValue("InputInnerTracks", {"InnerTracks"}),
+                        KeyValue("InputOuterTracks", {"OuterTracks"}),
                     },
                     {KeyValue("OutTracks", {"MyCandidateMergedTracks"})}) {}
 
   Gaudi::Property<bool> m_greedy{this, "Greedy", true, "If true, each track is used only once."};
 
-  TrackColl operator()(const TrackColl& inSiTracks, const TrackColl& inCluTracks) const override {
+  TrackColl operator()(const TrackColl& inputInnerTracks, const TrackColl& inputOuterTracks) const override {
     auto outTracks = TrackColl();
 
-    debug() << "Received SiTracks collection with " << inSiTracks.size() << " tracks" << endmsg;
-    debug() << "Received ClupatraTracks collection with " << inCluTracks.size() << " tracks" << endmsg;
+    debug() << "Received InnerTracks collection with " << inputInnerTracks.size() << " tracks" << endmsg;
+    debug() << "Received OuterTracks collection with " << inputOuterTracks.size() << " tracks" << endmsg;
 
     // 1. Check if both input collections have at least one entry
-    if (inSiTracks.empty() || inCluTracks.empty()) {
-      warning() << "One of the input collections is empty. SiTracks: " << inSiTracks.size()
-                << ", CluTracks: " << inCluTracks.size() << ". Skipping track merging for this event." << endmsg;
+    if (inputInnerTracks.empty() || inputOuterTracks.empty()) {
+      warning() << "One of the input collections is empty. InnerTracks: " << inputInnerTracks.size()
+                << ", OuterTracks: " << inputOuterTracks.size() << ". Skipping track merging for this event." << endmsg;
       return outTracks; // Returns empty collection
     }
 
-    // Flag to ensure each Clupatra track is only merged once
-    std::vector<bool> cluUsed(inCluTracks.size(), false);
+    // Flag to ensure each outer track is only merged once
+    std::vector<bool> usedOuterTracks(inputOuterTracks.size(), false);
 
-    // Loop over Silicon tracks with index for debug output
-    for (size_t iSi = 0; iSi < inSiTracks.size(); iSi++) {
-      const auto trackSi = inSiTracks[iSi];
+    // Loop over inner tracks with index for debug output
+    for (size_t iInner = 0; iInner < inputInnerTracks.size(); iInner++) {
+      const auto trackInner = inputInnerTracks[iInner];
       bool matched = false;
 
-      // Explicit index loop for Clupatra tracks to manage 'cluUsed' and debug indexing
+      // Explicit index loop for outer tracks to manage 'usedOuterTracks' and debug indexing
       // LOGIC NOTE: This algorithm accepts the FIRST match found within tolerances.
       // It does not perform a global chi2 minimization or search for the "best" match.
-      for (size_t iClu = 0; iClu < inCluTracks.size(); iClu++) {
-        if (m_greedy && cluUsed[iClu])
+      for (size_t iOuter = 0; iOuter < inputOuterTracks.size(); iOuter++) {
+        if (m_greedy && usedOuterTracks[iOuter])
           continue;
 
-        const auto trackClu = inCluTracks[iClu];
+        const auto trackOuter = inputOuterTracks[iOuter];
 
-        // compare trackSi and trackClu at their respective track states (Si: last hit (closest to TPC), Clu: first hit
-        // (closest to Si)) to determine if they likely originate from the same particle
-        if (isMatch(trackSi, TS::AtLastHit, trackClu, TS::AtFirstHit)) {
-          debug() << fmt::format("  [MATCH] SiTrack {} matched with CluTrack {}. Creating merged track.", iSi, iClu)
+        // compare trackInner and trackOuter at their respective track states (Inner: last hit, Outer: first hit)
+        // to determine if they likely originate from the same particle
+        if (isMatch(trackInner, TS::AtLastHit, trackOuter, TS::AtFirstHit)) {
+          debug() << fmt::format("  [MATCH] Inner track {} matched with Outer track {}. Creating merged track.",
+                                 iInner, iOuter)
                   << endmsg;
 
           auto newTrack = outTracks.create();
 
-          // Combine hits from both sub-detectors
-          for (const auto& hit : trackSi.getTrackerHits())
+          // Combine hits from both tracks
+          for (const auto& hit : trackInner.getTrackerHits())
             newTrack.addToTrackerHits(hit);
-          for (const auto& hit : trackClu.getTrackerHits())
+          for (const auto& hit : trackOuter.getTrackerHits())
             newTrack.addToTrackerHits(hit);
 
           // Maintain navigation/provenance by linking parent tracks
-          newTrack.addToTracks(trackSi);
-          newTrack.addToTracks(trackClu);
+          newTrack.addToTracks(trackInner);
+          newTrack.addToTracks(trackOuter);
 
           matched = true;
           if (m_greedy) {
-            cluUsed[iClu] = true;
-            break; // Exit inner loop: current SiTrack is satisfied
+            usedOuterTracks[iOuter] = true;
+            break; // Exit inner loop: current inner track is satisfied
           }
         }
       }
 
       if (!matched) {
-        debug() << fmt::format("  [INFO] SiTrack {} found no matching Clupatra track within tolerances.", iSi)
+        debug() << fmt::format("  [INFO] Inner track {} found no matching outer track within tolerances.", iInner)
                 << endmsg;
       }
     }
 
-    debug() << fmt::format("Event processing complete. Created {} merged tracks from {} SiTracks and {} CluTracks.",
-                           outTracks.size(), inSiTracks.size(), inCluTracks.size())
+    debug() << fmt::format(
+                   "Event processing complete. Created {} merged tracks from {} InnerTracks and {} OuterTracks.",
+                   outTracks.size(), inputInnerTracks.size(), inputOuterTracks.size())
             << endmsg;
     return outTracks;
   }

--- a/Tracking/components/TrackMerger.cpp
+++ b/Tracking/components/TrackMerger.cpp
@@ -44,6 +44,25 @@ struct TrackMerger final : k4FWCore::Transformer<TrackColl(const TrackColl&, con
 
   Gaudi::Property<bool> m_greedy{this, "Greedy", true, "If true, each track is used only once."};
 
+  // Per-parameter matching tolerances. A negative value disables that parameter for matching,
+  // i.e. it is not considered when deciding whether two tracks belong together.
+  // Defaults reproduce the original matching criterion: only D0 and Z0 are considered.
+  Gaudi::Property<float> m_d0Tolerance{
+      this, "D0Tolerance", 0.5f,
+      "Maximum allowed |D0(inner) - D0(outer)| for a match. Negative disables this criterion."};
+  Gaudi::Property<float> m_z0Tolerance{
+      this, "Z0Tolerance", 2.5f,
+      "Maximum allowed |Z0(inner) - Z0(outer)| for a match. Negative disables this criterion."};
+  Gaudi::Property<float> m_phiTolerance{
+      this, "PhiTolerance", -1.f,
+      "Maximum allowed |phi(inner) - phi(outer)| for a match. Negative disables this criterion."};
+  Gaudi::Property<float> m_omegaTolerance{
+      this, "OmegaTolerance", -1.f,
+      "Maximum allowed |omega(inner) - omega(outer)| for a match. Negative disables this criterion."};
+  Gaudi::Property<float> m_tanLambdaTolerance{
+      this, "TanLambdaTolerance", -1.f,
+      "Maximum allowed |tanLambda(inner) - tanLambda(outer)| for a match. Negative disables this criterion."};
+
   TrackColl operator()(const TrackColl& inputInnerTracks, const TrackColl& inputOuterTracks) const override {
     auto outTracks = TrackColl();
 
@@ -77,8 +96,8 @@ struct TrackMerger final : k4FWCore::Transformer<TrackColl(const TrackColl&, con
         // compare trackInner and trackOuter at their respective track states (Inner: last hit, Outer: first hit)
         // to determine if they likely originate from the same particle
         if (isMatch(trackInner, TS::AtLastHit, trackOuter, TS::AtFirstHit)) {
-          debug() << fmt::format("  [MATCH] Inner track {} matched with Outer track {}. Creating merged track.",
-                                 iInner, iOuter)
+          debug() << fmt::format("  [MATCH] Inner track {} matched with Outer track {}. Creating merged track.", iInner,
+                                 iOuter)
                   << endmsg;
 
           auto newTrack = outTracks.create();
@@ -125,27 +144,35 @@ private:
       return false;
     }
 
-    // Define matching criteria based on d0 and z0 differences
+    // Define matching criteria based on differences of the individual track parameters.
+    // Parameters whose tolerance is negative are not considered (always pass).
     const float d0_diff = std::abs(ts1->D0 - ts2->D0);
     const float z0_diff = std::abs(ts1->Z0 - ts2->Z0);
-    const bool match = (d0_diff <= 0.5f && z0_diff <= 2.5f);
+    const float phi_diff = std::abs(ts1->phi - ts2->phi);
+    const float omega_diff = std::abs(ts1->omega - ts2->omega);
+    const float tanLambda_diff = std::abs(ts1->tanLambda - ts2->tanLambda);
 
-    debug() << fmt::format("    Comparing Loc {} vs {}: d0_diff={:.4f}, z0_diff={:.4f} -> Match: {}", loc1, loc2,
-                           d0_diff, z0_diff, match)
+    const bool match = withinTolerance(d0_diff, m_d0Tolerance) && withinTolerance(z0_diff, m_z0Tolerance) &&
+                       withinTolerance(phi_diff, m_phiTolerance) && withinTolerance(omega_diff, m_omegaTolerance) &&
+                       withinTolerance(tanLambda_diff, m_tanLambdaTolerance);
+
+    debug() << fmt::format("    Comparing Loc {} vs {}: d0_diff={:.4f}, z0_diff={:.4f}, phi_diff={:.4f}, "
+                           "omega_diff={:.4f}, tanLambda_diff={:.4f} -> Match: {}",
+                           loc1, loc2, d0_diff, z0_diff, phi_diff, omega_diff, tanLambda_diff, match)
             << endmsg;
 
     return match;
   }
 
-  std::optional<const TS> getTrackState(const Track& track, const int loc) const {
-    const auto& trackStates = track.getTrackStates();
+  // A negative tolerance means the corresponding parameter is not considered for matching.
+  static bool withinTolerance(float diff, float tolerance) { return tolerance < 0.f || diff <= tolerance; }
 
-    if (auto it = std::ranges::find(trackStates, loc, &TS::location); it != trackStates.end()) {
-      return *it;
-    } else {
+  std::optional<TS> getTrackState(Track track, const int loc) const {
+    auto ts = track.getTrackState(loc);
+    if (!ts.has_value()) {
       warning() << std::format("No track state at location {} found!", loc) << endmsg;
-      return std::nullopt;
     }
+    return ts;
   }
 };
 

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -4,8 +4,8 @@ Minimalistic test for the TrackMerger Gaudi processor.
 What it does
 ------------
 1. Creates a small EDM4hep input file containing:
-   - SiTracksCT     : 2 tracks
-   - ClupatraTracks : 2 tracks
+   - InnerTracks : 2 tracks
+   - OuterTracks : 2 tracks
 
    Track pair 0 is set up to MATCH  (|d0_diff| <= 0.5, |z0_diff| <= 2.5).
    Track pair 1 is set up to NOT match (large d0/z0 offsets).
@@ -33,8 +33,8 @@ from edm4hep import TrackState as TS
 # ---------------------------------------------------------------------------
 # Constants that mirror the TrackMerger defaults
 # ---------------------------------------------------------------------------
-SI_COLL = "SiTracksCT"
-CLU_COLL = "ClupatraTracks"
+INNER_COLL = "InnerTracks"
+OUTER_COLL = "OuterTracks"
 OUT_COLL = "MyCandidateMergedTracks"
 
 # Match thresholds (from TrackMerger.cpp)
@@ -77,28 +77,28 @@ def write_input_file(path: str) -> None:
 
     frame = podio.Frame()
 
-    si_tracks = edm4hep.TrackCollection()
-    clu_tracks = edm4hep.TrackCollection()
+    inner_tracks = edm4hep.TrackCollection()
+    outer_tracks = edm4hep.TrackCollection()
 
-    si_hits = edm4hep.TrackerHit3DCollection()
-    clu_hits = edm4hep.TrackerHit3DCollection()
+    inner_hits = edm4hep.TrackerHit3DCollection()
+    outer_hits = edm4hep.TrackerHit3DCollection()
 
     # --- Pair 0: should MATCH ---
-    # SiTrack needs AtLastHit; CluTrack needs AtFirstHit
+    # Inner track needs AtLastHit; Outer track needs AtFirstHit
     # Using identical d0/z0 -> diff = 0, well within tolerance
     d0_match, z0_match = 1.0, 5.0
-    add_track(si_tracks, si_hits, TS.AtLastHit, d0_match, z0_match)
-    add_track(clu_tracks, clu_hits, TS.AtFirstHit, d0_match, z0_match)
+    add_track(inner_tracks, inner_hits, TS.AtLastHit, d0_match, z0_match)
+    add_track(outer_tracks, outer_hits, TS.AtFirstHit, d0_match, z0_match)
 
     # --- Pair 1: should NOT match ---
     # Offsets deliberately exceed both thresholds
-    add_track(si_tracks, si_hits, TS.AtLastHit, 10.0, 100.0)
-    add_track(clu_tracks, clu_hits, TS.AtFirstHit, 50.0, 500.0)
+    add_track(inner_tracks, inner_hits, TS.AtLastHit, 10.0, 100.0)
+    add_track(outer_tracks, outer_hits, TS.AtFirstHit, 50.0, 500.0)
 
-    frame.put(si_tracks, SI_COLL)
-    frame.put(clu_tracks, CLU_COLL)
-    frame.put(si_hits, "SiHits")
-    frame.put(clu_hits, "CluHits")
+    frame.put(inner_tracks, INNER_COLL)
+    frame.put(outer_tracks, OUTER_COLL)
+    frame.put(inner_hits, "InnerHits")
+    frame.put(outer_hits, "OuterHits")
 
     writer.write_frame(frame, "events")
     writer.finish()
@@ -117,10 +117,10 @@ iosvc.Input  = "{input}"
 iosvc.Output = "{output}"
 
 merger = TrackMerger("TrackMerger",
-    InputInnerTracks  = "{si_coll}",
-    InputOuterTracks = "{clu_coll}",
-    OutTracks      = "{out_coll}",
-    Greedy         = True,
+    InputInnerTracks = "{inner_coll}",
+    InputOuterTracks = "{outer_coll}",
+    OutTracks         = "{out_coll}",
+    Greedy            = True,
 )
 
 ApplicationMgr(
@@ -136,8 +136,8 @@ def write_steering_file(path: str, input_file: str, output_file: str) -> None:
     content = STEERING_TEMPLATE.format(
         input=input_file,
         output=output_file,
-        si_coll=SI_COLL,
-        clu_coll=CLU_COLL,
+        inner_coll=INNER_COLL,
+        outer_coll=OUTER_COLL,
         out_coll=OUT_COLL,
     )
     Path(path).write_text(content)
@@ -187,14 +187,14 @@ def check_output(output_file: str) -> None:
     # --- the merged track must link back to both parent tracks ---
     parent_tracks = list(merged_track.getTracks())
     assert len(parent_tracks) == 2, (
-        f"Merged track should carry 2 sub-tracks (SiTrack + CluTrack), got {len(parent_tracks)}"
+        f"Merged track should carry 2 sub-tracks (inner + outer), got {len(parent_tracks)}"
     )
 
     # --- it must aggregate hits from both parents ---
     total_parent_hits = sum(len(list(p.getTrackerHits())) for p in parent_tracks)
     merged_hits = len(list(merged_track.getTrackerHits()))
     assert merged_hits == total_parent_hits, (
-        f"Merged track should have {total_parent_hits} hits (1 from Si + 1 from Clu), "
+        f"Merged track should have {total_parent_hits} hits (1 from inner + 1 from outer), "
         f"got {merged_hits}"
     )
 

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -1,0 +1,223 @@
+"""
+Minimalistic test for the TrackMerger Gaudi processor.
+
+What it does
+------------
+1. Creates a small EDM4hep input file containing:
+   - SiTracksCT     : 2 tracks
+   - ClupatraTracks : 2 tracks
+
+   Track pair 0 is set up to MATCH  (|d0_diff| <= 0.5, |z0_diff| <= 2.5).
+   Track pair 1 is set up to NOT match (large d0/z0 offsets).
+
+2. Runs TrackMerger via a minimal Gaudi job (k4run).
+
+3. Reads the output file and asserts that exactly 1 merged track was produced,
+   that it carries hits from both parent tracks, and that it links back to both
+   parent tracks.
+
+Requirements
+------------
+  pip install podio edm4hep   (or load the key4hep stack)
+  k4run must be on PATH
+"""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import edm4hep
+import podio
+from edm4hep import TrackState as TS
+
+# ---------------------------------------------------------------------------
+# Constants that mirror the TrackMerger defaults
+# ---------------------------------------------------------------------------
+SI_COLL = "SiTracksCT"
+CLU_COLL = "ClupatraTracks"
+OUT_COLL = "MyCandidateMergedTracks"
+
+# Match thresholds (from TrackMerger.cpp)
+D0_TOL = 0.5
+Z0_TOL = 2.5
+
+
+# ---------------------------------------------------------------------------
+# Helper: build one TrackState with the minimum required fields
+# ---------------------------------------------------------------------------
+def make_track_state(location: int, d0: float, z0: float) -> edm4hep.TrackState:
+    ts = edm4hep.TrackState()
+    ts.location = location
+    ts.D0 = d0
+    ts.Z0 = z0
+    ts.phi = 0.0
+    ts.omega = 1e-4  # small curvature, arbitrary
+    ts.tanLambda = 0.5
+    return ts
+
+
+# ---------------------------------------------------------------------------
+# Helper: add a track with one TrackState and one dummy TrackerHit
+# ---------------------------------------------------------------------------
+def add_track(collection, hit_collection, location: int, d0: float, z0: float):
+    hit = hit_collection.create()
+    hit.setPosition(edm4hep.Vector3d(0.0, 0.0, 0.0))
+
+    trk = collection.create()
+    trk.addToTrackerHits(hit)
+    trk.addToTrackStates(make_track_state(location, d0, z0))
+    return trk
+
+
+# ---------------------------------------------------------------------------
+# Step 1 - write the input file
+# ---------------------------------------------------------------------------
+def write_input_file(path: str) -> None:
+    writer = podio.root_io.Writer(path)
+
+    frame = podio.Frame()
+
+    si_tracks = edm4hep.TrackCollection()
+    clu_tracks = edm4hep.TrackCollection()
+
+    si_hits = edm4hep.TrackerHit3DCollection()
+    clu_hits = edm4hep.TrackerHit3DCollection()
+
+    # --- Pair 0: should MATCH ---
+    # SiTrack needs AtLastHit; CluTrack needs AtFirstHit
+    # Using identical d0/z0 -> diff = 0, well within tolerance
+    d0_match, z0_match = 1.0, 5.0
+    add_track(si_tracks, si_hits, TS.AtLastHit, d0_match, z0_match)
+    add_track(clu_tracks, clu_hits, TS.AtFirstHit, d0_match, z0_match)
+
+    # --- Pair 1: should NOT match ---
+    # Offsets deliberately exceed both thresholds
+    add_track(si_tracks, si_hits, TS.AtLastHit, 10.0, 100.0)
+    add_track(clu_tracks, clu_hits, TS.AtFirstHit, 50.0, 500.0)
+
+    frame.put(si_tracks, SI_COLL)
+    frame.put(clu_tracks, CLU_COLL)
+    frame.put(si_hits, "SiHits")
+    frame.put(clu_hits, "CluHits")
+
+    writer.write_frame(frame, "events")
+    writer.finish()
+    print(f"[setup] Wrote input file: {path}")
+
+
+# ---------------------------------------------------------------------------
+# Step 2 - write a minimal Gaudi steering file on-the-fly
+# ---------------------------------------------------------------------------
+STEERING_TEMPLATE = """\
+from Configurables import TrackMerger
+from k4FWCore import ApplicationMgr, IOSvc
+
+iosvc = IOSvc()
+iosvc.Input  = "{input}"
+iosvc.Output = "{output}"
+
+merger = TrackMerger("TrackMerger",
+    InputSiTracks  = "{si_coll}",
+    InputCluTracks = "{clu_coll}",
+    OutTracks      = "{out_coll}",
+    Greedy         = True,
+)
+
+ApplicationMgr(
+    TopAlg  = [merger],
+    EvtSel  = "NONE",
+    EvtMax  = 1,
+    ExtSvc  = [iosvc],
+)
+"""
+
+
+def write_steering_file(path: str, input_file: str, output_file: str) -> None:
+    content = STEERING_TEMPLATE.format(
+        input=input_file,
+        output=output_file,
+        si_coll=SI_COLL,
+        clu_coll=CLU_COLL,
+        out_coll=OUT_COLL,
+    )
+    Path(path).write_text(content)
+    print(f"[setup] Wrote steering file: {path}")
+
+
+# ---------------------------------------------------------------------------
+# Step 3 - run Gaudi
+# ---------------------------------------------------------------------------
+def run_gaudi(steering_file: str) -> None:
+    result = subprocess.run(
+        ["k4run", steering_file],
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout[-3000:])  # tail to keep output readable
+    if result.returncode != 0:
+        print(result.stderr[-2000:])
+        raise RuntimeError(f"k4run failed (exit {result.returncode})")
+    print("[run] Gaudi job finished successfully.")
+
+
+# ---------------------------------------------------------------------------
+# Step 4 - read back & assert
+# ---------------------------------------------------------------------------
+def check_output(output_file: str) -> None:
+    reader = podio.root_io.Reader(output_file)
+
+    frames = list(reader.get("events"))
+    assert len(frames) == 1, f"Expected 1 event frame, got {len(frames)}"
+
+    frame = frames[0]
+
+    assert OUT_COLL in frame.getAvailableCollections(), (
+        f"Output collection '{OUT_COLL}' not found in output file"
+    )
+
+    merged = frame.get(OUT_COLL)
+
+    # --- core assertion: exactly one pair should have merged ---
+    assert len(merged) == 1, (
+        f"Expected 1 merged track (pair 0 matches, pair 1 does not), got {len(merged)}"
+    )
+
+    merged_track = merged[0]
+
+    # --- the merged track must link back to both parent tracks ---
+    parent_tracks = list(merged_track.getTracks())
+    assert len(parent_tracks) == 2, (
+        f"Merged track should carry 2 sub-tracks (SiTrack + CluTrack), got {len(parent_tracks)}"
+    )
+
+    # --- it must aggregate hits from both parents ---
+    total_parent_hits = sum(len(list(p.getTrackerHits())) for p in parent_tracks)
+    merged_hits = len(list(merged_track.getTrackerHits()))
+    assert merged_hits == total_parent_hits, (
+        f"Merged track should have {total_parent_hits} hits (1 from Si + 1 from Clu), "
+        f"got {merged_hits}"
+    )
+
+    print("[check] All assertions passed.")
+    print(f"        merged tracks : {len(merged)}")
+    print(f"        parent links  : {len(parent_tracks)}")
+    print(f"        merged hits   : {merged_hits}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point (also works as a standalone script)
+# ---------------------------------------------------------------------------
+def test_track_merger():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_file = str(Path(tmpdir) / "input.root")
+        output_file = str(Path(tmpdir) / "output.root")
+        steering_file = str(Path(tmpdir) / "steer.py")
+
+        write_input_file(input_file)
+        write_steering_file(steering_file, input_file, output_file)
+        run_gaudi(steering_file)
+        check_output(output_file)
+
+
+if __name__ == "__main__":
+    test_track_merger()

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -39,7 +39,6 @@ from pathlib import Path
 
 import edm4hep
 import podio
-from edm4hep import TrackState as TS
 
 # ---------------------------------------------------------------------------
 # Constants that mirror the TrackMerger defaults.
@@ -97,13 +96,13 @@ def write_input_file(path: str) -> None:
     # Inner track needs AtLastHit; Outer track needs AtFirstHit
     # Using identical d0/z0 -> diff = 0, well within tolerance
     d0_match, z0_match = 1.0, 5.0
-    add_track(inner_tracks, inner_hits, TS.AtLastHit, d0_match, z0_match)
-    add_track(outer_tracks, outer_hits, TS.AtFirstHit, d0_match, z0_match)
+    add_track(inner_tracks, inner_hits, edm4hep.TrackState.AtLastHit, d0_match, z0_match)
+    add_track(outer_tracks, outer_hits, edm4hep.TrackState.AtFirstHit, d0_match, z0_match)
 
     # --- Pair 1: should NOT match ---
     # Offsets deliberately exceed both thresholds
-    add_track(inner_tracks, inner_hits, TS.AtLastHit, 10.0, 100.0)
-    add_track(outer_tracks, outer_hits, TS.AtFirstHit, 50.0, 500.0)
+    add_track(inner_tracks, inner_hits, edm4hep.TrackState.AtLastHit, 10.0, 100.0)
+    add_track(outer_tracks, outer_hits, edm4hep.TrackState.AtFirstHit, 50.0, 500.0)
 
     frame.put(inner_tracks, INNER_COLL)
     frame.put(outer_tracks, OUTER_COLL)

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -3,21 +3,29 @@ Minimalistic test for the TrackMerger Gaudi processor.
 
 What it does
 ------------
-1. Creates a small EDM4hep input file containing:
+1. (run step) Creates a small EDM4hep input file containing:
    - InnerTracks : 2 tracks
    - OuterTracks : 2 tracks
 
    Track pair 0 is set up to MATCH  (|d0_diff| <= 0.5, |z0_diff| <= 2.5).
    Track pair 1 is set up to NOT match (large d0/z0 offsets).
 
-2. Runs TrackMerger via a minimal Gaudi job (k4run), explicitly setting all 5
-   per-parameter tolerances (D0Tolerance, Z0Tolerance, PhiTolerance,
-   OmegaTolerance, TanLambdaTolerance) to exercise their configurability from
-   the steering file.
+   Then runs TrackMerger via test_track_merger_steer.py (k4run), which sets
+   all 5 per-parameter tolerances (D0Tolerance, Z0Tolerance, PhiTolerance,
+   OmegaTolerance, TanLambdaTolerance) to exercise their configurability.
 
-3. Reads the output file and asserts that exactly 1 merged track was produced,
-   that it carries hits from both parent tracks, and that it links back to both
-   parent tracks.
+2. (check step) Reads the output file and asserts that exactly 1 merged track
+   was produced, that it carries hits from both parent tracks, and that it
+   links back to both parent tracks.
+
+The run and check steps are split into two subcommands so that CMake can run
+them as separate tests with a fixture dependency between them, while sharing
+all collection names/tolerances defined once in this file.
+
+Usage
+-----
+    python3 test_track_merger.py run   --input input.root --output output.root
+    python3 test_track_merger.py check --output output.root
 
 Requirements
 ------------
@@ -25,8 +33,8 @@ Requirements
   k4run must be on PATH
 """
 
+import argparse
 import subprocess
-import tempfile
 from pathlib import Path
 
 import edm4hep
@@ -34,19 +42,14 @@ import podio
 from edm4hep import TrackState as TS
 
 # ---------------------------------------------------------------------------
-# Constants that mirror the TrackMerger defaults
+# Constants that mirror the TrackMerger defaults.
+# Must be kept in sync with the constants in test_track_merger_steer.py.
 # ---------------------------------------------------------------------------
 INNER_COLL = "InnerTracks"
 OUTER_COLL = "OuterTracks"
 OUT_COLL = "MyCandidateMergedTracks"
 
-# Match thresholds (mirroring TrackMerger.cpp defaults).
-# Negative disables that parameter for matching.
-D0_TOL = 0.5
-Z0_TOL = 2.5
-PHI_TOL = -1.0
-OMEGA_TOL = -1.0
-TAN_LAMBDA_TOL = -1.0
+STEERING_FILE = Path(__file__).parent / "test_track_merger_steer.py"
 
 
 # ---------------------------------------------------------------------------
@@ -113,60 +116,11 @@ def write_input_file(path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 2 - write a minimal Gaudi steering file on-the-fly
+# Step 2 - run Gaudi via the standalone steering file
 # ---------------------------------------------------------------------------
-STEERING_TEMPLATE = """\
-from Configurables import TrackMerger
-from k4FWCore import ApplicationMgr, IOSvc
-
-iosvc = IOSvc()
-iosvc.Input  = "{input}"
-iosvc.Output = "{output}"
-
-merger = TrackMerger("TrackMerger",
-    InputInnerTracks   = "{inner_coll}",
-    InputOuterTracks   = "{outer_coll}",
-    OutTracks          = "{out_coll}",
-    Greedy             = True,
-    D0Tolerance        = {d0_tol},
-    Z0Tolerance        = {z0_tol},
-    PhiTolerance       = {phi_tol},
-    OmegaTolerance     = {omega_tol},
-    TanLambdaTolerance = {tan_lambda_tol},
-)
-
-ApplicationMgr(
-    TopAlg  = [merger],
-    EvtSel  = "NONE",
-    EvtMax  = 1,
-    ExtSvc  = [iosvc],
-)
-"""
-
-
-def write_steering_file(path: str, input_file: str, output_file: str) -> None:
-    content = STEERING_TEMPLATE.format(
-        input=input_file,
-        output=output_file,
-        inner_coll=INNER_COLL,
-        outer_coll=OUTER_COLL,
-        out_coll=OUT_COLL,
-        d0_tol=D0_TOL,
-        z0_tol=Z0_TOL,
-        phi_tol=PHI_TOL,
-        omega_tol=OMEGA_TOL,
-        tan_lambda_tol=TAN_LAMBDA_TOL,
-    )
-    Path(path).write_text(content)
-    print(f"[setup] Wrote steering file: {path}")
-
-
-# ---------------------------------------------------------------------------
-# Step 3 - run Gaudi
-# ---------------------------------------------------------------------------
-def run_gaudi(steering_file: str) -> None:
+def run_gaudi(input_file: str, output_file: str) -> None:
     result = subprocess.run(
-        ["k4run", steering_file],
+        ["k4run", str(STEERING_FILE), "--input", input_file, "--output", output_file],
         capture_output=True,
         text=True,
     )
@@ -178,7 +132,7 @@ def run_gaudi(steering_file: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 4 - read back & assert
+# Step 3 - read back & assert
 # ---------------------------------------------------------------------------
 def check_output(output_file: str) -> None:
     reader = podio.root_io.Reader(output_file)
@@ -222,19 +176,27 @@ def check_output(output_file: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Entry point (also works as a standalone script)
+# Entry point
 # ---------------------------------------------------------------------------
-def test_track_merger():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        input_file = str(Path(tmpdir) / "input.root")
-        output_file = str(Path(tmpdir) / "output.root")
-        steering_file = str(Path(tmpdir) / "steer.py")
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="step", required=True)
 
-        write_input_file(input_file)
-        write_steering_file(steering_file, input_file, output_file)
-        run_gaudi(steering_file)
-        check_output(output_file)
+    run_parser = subparsers.add_parser("run", help="Write input file and run TrackMerger")
+    run_parser.add_argument("--input", default="input.root")
+    run_parser.add_argument("--output", default="output.root")
+
+    check_parser = subparsers.add_parser("check", help="Check the TrackMerger output file")
+    check_parser.add_argument("--output", default="output.root")
+
+    args = parser.parse_args()
+
+    if args.step == "run":
+        write_input_file(args.input)
+        run_gaudi(args.input, args.output)
+    elif args.step == "check":
+        check_output(args.output)
 
 
 if __name__ == "__main__":
-    test_track_merger()
+    main()

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -117,8 +117,8 @@ iosvc.Input  = "{input}"
 iosvc.Output = "{output}"
 
 merger = TrackMerger("TrackMerger",
-    InputSiTracks  = "{si_coll}",
-    InputCluTracks = "{clu_coll}",
+    InputInnerTracks  = "{si_coll}",
+    InputOuterTracks = "{clu_coll}",
     OutTracks      = "{out_coll}",
     Greedy         = True,
 )

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -111,23 +111,7 @@ def write_input_file(path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 2 - run Gaudi via the standalone steering file
-# ---------------------------------------------------------------------------
-def run_gaudi(input_file: str, output_file: str) -> None:
-    result = subprocess.run(
-        ["k4run", str(STEERING_FILE), "--input", input_file, "--output", output_file],
-        capture_output=True,
-        text=True,
-    )
-    print(result.stdout[-3000:])  # tail to keep output readable
-    if result.returncode != 0:
-        print(result.stderr[-2000:])
-        raise RuntimeError(f"k4run failed (exit {result.returncode})")
-    print("[run] Gaudi job finished successfully.")
-
-
-# ---------------------------------------------------------------------------
-# Step 3 - read back & assert
+# Step 2 - read back & assert
 # ---------------------------------------------------------------------------
 def check_output(output_file: str) -> None:
     reader = podio.root_io.Reader(output_file)

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -34,8 +34,6 @@ Requirements
 """
 
 import argparse
-import subprocess
-from pathlib import Path
 
 import edm4hep
 import podio
@@ -47,8 +45,6 @@ import podio
 INNER_COLL = "InnerTracks"
 OUTER_COLL = "OuterTracks"
 OUT_COLL = "MyCandidateMergedTracks"
-
-STEERING_FILE = Path(__file__).parent / "test_track_merger_steer.py"
 
 
 # ---------------------------------------------------------------------------
@@ -181,18 +177,16 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="step", required=True)
 
-    run_parser = subparsers.add_parser("run", help="Write input file and run TrackMerger")
-    run_parser.add_argument("--input", default="input.root")
-    run_parser.add_argument("--output", default="output.root")
+    setup_parser = subparsers.add_parser("setup", help="Write the input file")
+    setup_parser.add_argument("--input", default="input.root")
 
     check_parser = subparsers.add_parser("check", help="Check the TrackMerger output file")
     check_parser.add_argument("--output", default="output.root")
 
     args = parser.parse_args()
 
-    if args.step == "run":
+    if args.step == "setup":
         write_input_file(args.input)
-        run_gaudi(args.input, args.output)
     elif args.step == "check":
         check_output(args.output)
 

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -10,7 +10,10 @@ What it does
    Track pair 0 is set up to MATCH  (|d0_diff| <= 0.5, |z0_diff| <= 2.5).
    Track pair 1 is set up to NOT match (large d0/z0 offsets).
 
-2. Runs TrackMerger via a minimal Gaudi job (k4run).
+2. Runs TrackMerger via a minimal Gaudi job (k4run), explicitly setting all 5
+   per-parameter tolerances (D0Tolerance, Z0Tolerance, PhiTolerance,
+   OmegaTolerance, TanLambdaTolerance) to exercise their configurability from
+   the steering file.
 
 3. Reads the output file and asserts that exactly 1 merged track was produced,
    that it carries hits from both parent tracks, and that it links back to both
@@ -37,9 +40,13 @@ INNER_COLL = "InnerTracks"
 OUTER_COLL = "OuterTracks"
 OUT_COLL = "MyCandidateMergedTracks"
 
-# Match thresholds (from TrackMerger.cpp)
+# Match thresholds (mirroring TrackMerger.cpp defaults).
+# Negative disables that parameter for matching.
 D0_TOL = 0.5
 Z0_TOL = 2.5
+PHI_TOL = -1.0
+OMEGA_TOL = -1.0
+TAN_LAMBDA_TOL = -1.0
 
 
 # ---------------------------------------------------------------------------
@@ -117,10 +124,15 @@ iosvc.Input  = "{input}"
 iosvc.Output = "{output}"
 
 merger = TrackMerger("TrackMerger",
-    InputInnerTracks = "{inner_coll}",
-    InputOuterTracks = "{outer_coll}",
-    OutTracks         = "{out_coll}",
-    Greedy            = True,
+    InputInnerTracks   = "{inner_coll}",
+    InputOuterTracks   = "{outer_coll}",
+    OutTracks          = "{out_coll}",
+    Greedy             = True,
+    D0Tolerance        = {d0_tol},
+    Z0Tolerance        = {z0_tol},
+    PhiTolerance       = {phi_tol},
+    OmegaTolerance     = {omega_tol},
+    TanLambdaTolerance = {tan_lambda_tol},
 )
 
 ApplicationMgr(
@@ -139,6 +151,11 @@ def write_steering_file(path: str, input_file: str, output_file: str) -> None:
         inner_coll=INNER_COLL,
         outer_coll=OUTER_COLL,
         out_coll=OUT_COLL,
+        d0_tol=D0_TOL,
+        z0_tol=Z0_TOL,
+        phi_tol=PHI_TOL,
+        omega_tol=OMEGA_TOL,
+        tan_lambda_tol=TAN_LAMBDA_TOL,
     )
     Path(path).write_text(content)
     print(f"[setup] Wrote steering file: {path}")

--- a/Tracking/test/testTrackMerger/test_track_merger.py
+++ b/Tracking/test/testTrackMerger/test_track_merger.py
@@ -3,34 +3,35 @@ Minimalistic test for the TrackMerger Gaudi processor.
 
 What it does
 ------------
-1. (run step) Creates a small EDM4hep input file containing:
+1. (setup step) Creates a small EDM4hep input file containing:
    - InnerTracks : 2 tracks
    - OuterTracks : 2 tracks
 
    Track pair 0 is set up to MATCH  (|d0_diff| <= 0.5, |z0_diff| <= 2.5).
    Track pair 1 is set up to NOT match (large d0/z0 offsets).
 
-   Then runs TrackMerger via test_track_merger_steer.py (k4run), which sets
-   all 5 per-parameter tolerances (D0Tolerance, Z0Tolerance, PhiTolerance,
-   OmegaTolerance, TanLambdaTolerance) to exercise their configurability.
+   TrackMerger itself is run separately by CTest via
+   `k4run test_track_merger_steer.py`, which sets all 5 per-parameter
+   tolerances (D0Tolerance, Z0Tolerance, PhiTolerance, OmegaTolerance,
+   TanLambdaTolerance) to exercise their configurability.
 
 2. (check step) Reads the output file and asserts that exactly 1 merged track
    was produced, that it carries hits from both parent tracks, and that it
    links back to both parent tracks.
 
-The run and check steps are split into two subcommands so that CMake can run
-them as separate tests with a fixture dependency between them, while sharing
-all collection names/tolerances defined once in this file.
+The setup and check steps are split into two subcommands so that CMake can
+run them (and the k4run step in between) as separate tests chained via
+fixtures, while sharing all collection names defined once in this file.
 
 Usage
 -----
-    python3 test_track_merger.py run   --input input.root --output output.root
-    python3 test_track_merger.py check --output output.root
+    python3 test_track_merger.py setup   --input input.root
+    k4run test_track_merger_steer.py     --input input.root --output output.root
+    python3 test_track_merger.py check   --output output.root
 
 Requirements
 ------------
   pip install podio edm4hep   (or load the key4hep stack)
-  k4run must be on PATH
 """
 
 import argparse

--- a/Tracking/test/testTrackMerger/test_track_merger_steer.py
+++ b/Tracking/test/testTrackMerger/test_track_merger_steer.py
@@ -1,0 +1,56 @@
+"""
+Steering file for the TrackMerger test.
+
+Can be run standalone with:
+
+    k4run test_track_merger_steer.py
+
+Input/output file names default to sensible values but are exposed via CLI
+so the test driver can override them.
+"""
+
+from Configurables import TrackMerger
+from k4FWCore import ApplicationMgr, IOSvc
+from k4FWCore.parseArgs import parser
+
+# ---------------------------------------------------------------------------
+# Collection names and matching tolerances.
+# Must be kept in sync with the constants in test_track_merger.py.
+# ---------------------------------------------------------------------------
+INNER_COLL = "InnerTracks"
+OUTER_COLL = "OuterTracks"
+OUT_COLL = "MyCandidateMergedTracks"
+
+D0_TOL = 0.5
+Z0_TOL = 2.5
+PHI_TOL = -1.0
+OMEGA_TOL = -1.0
+TAN_LAMBDA_TOL = -1.0
+
+parser.add_argument("--input", default="input.root", help="Input EDM4hep file")
+parser.add_argument("--output", default="output.root", help="Output EDM4hep file")
+args = parser.parse_known_args()[0]
+
+iosvc = IOSvc()
+iosvc.Input = args.input
+iosvc.Output = args.output
+
+merger = TrackMerger(
+    "TrackMerger",
+    InputInnerTracks=INNER_COLL,
+    InputOuterTracks=OUTER_COLL,
+    OutTracks=OUT_COLL,
+    Greedy=True,
+    D0Tolerance=D0_TOL,
+    Z0Tolerance=Z0_TOL,
+    PhiTolerance=PHI_TOL,
+    OmegaTolerance=OMEGA_TOL,
+    TanLambdaTolerance=TAN_LAMBDA_TOL,
+)
+
+ApplicationMgr(
+    TopAlg=[merger],
+    EvtSel="NONE",
+    EvtMax=1,
+    ExtSvc=[iosvc],
+)

--- a/Tracking/test/testTrackMerger/test_track_merger_steer.py
+++ b/Tracking/test/testTrackMerger/test_track_merger_steer.py
@@ -1,12 +1,12 @@
 """
 Steering file for the TrackMerger test.
 
-Can be run standalone with:
+Run with:
 
-    k4run test_track_merger_steer.py
+    k4run test_track_merger_steer.py --input input.root --output output.root
 
-Input/output file names default to sensible values but are exposed via CLI
-so the test driver can override them.
+Input/output file names default to sensible values but can be overridden
+via CLI, e.g. by the CTest setup in CMakeLists.
 """
 
 from Configurables import TrackMerger


### PR DESCRIPTION
BEGINRELEASENOTES
- Adds a new `TrackMerger` Gaudi transformer that merges tracks from two input collections based on compatible track-state parameters at their adjoining hit
- While generic and applicable to merging any two track collections, it was designed to combine silicon-tracker tracks with TPC tracks reconstructed by `Clupatra` for ILD
- The exact matching criterion in track-parameter space is not yet optimized and may need tuning
- Includes self-contained CTest `test_TrackMerger*` that generates synthetic matching/non-matching track pairs and verifies correct merging behavior

ENDRELEASENOTES
