### PR TITLE
Tracking: fix post-fit TrackState, reset TGeoManager before each fit, correct the Jacobian, remove noise tracks from GGTF output and suppress error messages with debugLvl=INFO

### DIFF
--- a/Tracking/components/GGTFTrackFinder.cpp
+++ b/Tracking/components/GGTFTrackFinder.cpp
@@ -18,46 +18,31 @@
  */
 
 // Standard Library
-#include <algorithm>
+#include <atomic>
 #include <cmath>
-#include <cstdlib>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include <iterator>
-#include <map>
+#include <cstdint>
+#include <limits>
 #include <memory>
-#include <numeric>
-#include <queue>
-#include <random>
-#include <sstream>
+#include <stdexcept>
 #include <string>
-#include <typeinfo>
+#include <tuple>
 #include <vector>
 
-// ONNX & Torch
+// ONNX Runtime and Torch
 #include "onnxruntime_cxx_api.h"
-#include "onnxruntime_run_options_config_keys.h"
-#include <ATen/ATen.h>
 #include <torch/torch.h>
 
 // ROOT
 #include "TVector3.h"
 
 // Gaudi
-#include "Gaudi/Algorithm.h"
 #include "Gaudi/Property.h"
 
-// k4FWCore / k4Interface
-#include "k4FWCore/DataHandle.h"
+// k4FWCore
 #include "k4FWCore/Transformer.h"
-#include "k4Interface/IGeoSvc.h"
-#include "k4Interface/IUniqueIDGenSvc.h"
 
 // EDM4HEP
-#include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SenseWireHitCollection.h"
-#include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 
@@ -67,9 +52,10 @@
  *
  * Gaudi MultiTransformer that generates a Track collection by analyzing the digitalized hits through the
  * GGTFTrackFinder. The first step takes the raw hits and it returns a collection of 4-dimensional points inside an
- * embedding space. Eeach 4-dim point has 3 geometric coordinates and 1 charge, the meaning of which can be described
- * intuitively by a potential, which attracts hits belonging to the same cluster and drives away those that do not. This
- * collection of 4-dim points is analysed by a clustering step, which groups together hits belonging to the same track.
+ * embedding space. Each 4-dim point has 3 geometric coordinates and 1 charge, the meaning of which can be described
+ * intuitively by a potential, which attracts hits belonging to the same cluster and drives away those that do not.
+ * This collection of 4-dim points is analysed by a clustering step, which groups together hits belonging to the
+ * same track.
  *
  *  input:
  *    - digitalized hits from DC (global coordinates) : edm4hep::SenseWireHitCollection
@@ -83,60 +69,49 @@
  *  @author Andrea De Vita, Maria Dolores Garcia, Brieuc Francois
  *  @date   2025-11
  *
+ * @note Cluster identifier zero is treated as noise and does not create a track.
  */
-
 struct GGTFTrackFinder final : k4FWCore::MultiTransformer<std::tuple<edm4hep::TrackCollection>(
                                    const std::vector<const edm4hep::TrackerHitPlaneCollection*>&,
                                    const std::vector<const edm4hep::SenseWireHitCollection*>&)> {
 
   GGTFTrackFinder(const std::string& name, ISvcLocator* svcLoc)
       : MultiTransformer(name, svcLoc,
-                         {
-
-                             KeyValues("InputPlanarHitCollections", {"InputPlanarHitCollections"}),
-                             KeyValues("InputWireHitCollections", {"InputWireHitCollections"})
-
-                         },
-                         {
-
-                             KeyValues("OutputTracksGGTF", {"OutputTracksGGTF"})
-
-                         }) {}
+                         {KeyValues("InputPlanarHitCollections", {"InputPlanarHitCollections"}),
+                          KeyValues("InputWireHitCollections", {"InputWireHitCollections"})},
+                         {KeyValues("OutputTracksGGTF", {"OutputTracksGGTF"})}) {}
 
   StatusCode initialize() override {
+    if (m_modelPath.value().empty()) {
+      error() << "ModelPath is empty; an ONNX model file must be configured." << endmsg;
+      return StatusCode::FAILURE;
+    }
 
-    ///////////////////////////////
-    ///// ONNX Initialization /////
-    ///////////////////////////////
+    try {
+      m_memoryInfo =
+          std::make_unique<Ort::MemoryInfo>(Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault));
+      m_environment = std::make_unique<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, "GGTFTrackFinder");
 
-    // Initialize the ONNX memory info object for CPU memory allocation.
-    m_fInfo = std::make_unique<Ort::MemoryInfo>(Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault));
+      m_sessionOptions.SetIntraOpNumThreads(1);
+      m_sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
 
-    // Create and initialize the ONNX environment with a logging level set to WARNING.
-    auto envLocal = std::make_unique<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, "ONNX_Runtime");
-    m_fEnv = std::move(envLocal);
+      m_session = std::make_unique<Ort::Session>(*m_environment, m_modelPath.value().c_str(), m_sessionOptions);
 
-    // Set the session options to configure the ONNX inference session.
-    m_fSessionOptions.SetIntraOpNumThreads(1);
+      if (m_session->GetInputCount() != 1 || m_session->GetOutputCount() != 1) {
+        error() << "The configured model must expose exactly one input and one output." << endmsg;
+        return StatusCode::FAILURE;
+      }
 
-    // Disable all graph optimizations to keep the model execution as close to the original as possible.
-    m_fSessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_DISABLE_ALL);
-
-    // Create an ONNX inference session to load the model specified by the `modelPath`.
-    auto sessionLocal = std::make_unique<Ort::Session>(*m_fEnv, m_modelPath.value().c_str(), m_fSessionOptions);
-    m_fSession = std::move(sessionLocal);
-
-    // Create an ONNX allocator with default options to manage memory allocations during runtime.
-    Ort::AllocatorWithDefaultOptions allocator;
-
-    // Get the name of the first input node (index i) from the ONNX model and store it.
-    // Get the name of the first output node (index i) from the ONNX model and store it.
-    std::size_t i = 0;
-    const auto inputNames = m_fSession->GetInputNameAllocated(i, allocator).release();
-    const auto outputNames = m_fSession->GetOutputNameAllocated(i, allocator).release();
-
-    m_fInames.push_back(inputNames);
-    m_fOnames.push_back(outputNames);
+      Ort::AllocatorWithDefaultOptions allocator;
+      m_inputName = m_session->GetInputNameAllocated(0, allocator).get();
+      m_outputName = m_session->GetOutputNameAllocated(0, allocator).get();
+    } catch (const Ort::Exception& exception) {
+      error() << "Failed to initialize ONNX Runtime: " << exception.what() << endmsg;
+      return StatusCode::FAILURE;
+    } catch (const std::exception& exception) {
+      error() << "Failed to initialize GGTFTrackFinder: " << exception.what() << endmsg;
+      return StatusCode::FAILURE;
+    }
 
     return StatusCode::SUCCESS;
   }
@@ -144,295 +119,315 @@ struct GGTFTrackFinder final : k4FWCore::MultiTransformer<std::tuple<edm4hep::Tr
   std::tuple<edm4hep::TrackCollection>
   operator()(const std::vector<const edm4hep::TrackerHitPlaneCollection*>& inputPlanarHitCollections,
              const std::vector<const edm4hep::SenseWireHitCollection*>& inputWireHitCollections) const override {
+    const std::uint64_t eventNumber = m_eventCounter.fetch_add(1, std::memory_order_relaxed);
+    info() << "Processing event number: " << eventNumber << endmsg;
 
-    ////////////////////////////////////////
-    ////////// DATA PREPROCESSING //////////
-    ////////////////////////////////////////
-
-    info() << "Processing event number: " << m_indexCounter++ << endmsg;
-
-    // Vector to store the global input values for all hits.
-    // This will contain position and other hit-specific data to be used as input for the model.
-    std::vector<float> listGlobalInputs;
-    int globalHitIndex = 0;
-
-    /// Processing hits from the Silicon Detectors
-    std::vector<int64_t> listHitTypePlanar;
-    int planarHitIndex = 0;
-    std::vector<int64_t> listPlanarHitIndices;
-    int planarHitCollectionIndex = 0;
-    for (const auto& inputHitCollection : inputPlanarHitCollections) {
-
-      int planarHitSubCollectionIndex = 0;
-      for (const auto& inputHit : *inputHitCollection) {
-
-        // Add the 3D position of the hit to the global input list.
-        listGlobalInputs.push_back(inputHit.getPosition().x);
-        listGlobalInputs.push_back(inputHit.getPosition().y);
-        listGlobalInputs.push_back(inputHit.getPosition().z);
-
-        // Add placeholder values for additional input dimensions.
-        listGlobalInputs.push_back(1.0);
-        listGlobalInputs.push_back(0.0);
-        listGlobalInputs.push_back(0.0);
-        listGlobalInputs.push_back(0.0);
-
-        listHitTypePlanar.push_back(globalHitIndex);
-
-        listPlanarHitIndices.push_back(planarHitCollectionIndex);
-        listPlanarHitIndices.push_back(planarHitSubCollectionIndex);
-
-        globalHitIndex += 1;
-        planarHitIndex += 1;
-        planarHitSubCollectionIndex += 1;
-      }
-
-      planarHitCollectionIndex += 1;
-    }
-    // Convert listHitTypePlanar to a Torch tensor for use in PyTorch models.
-    torch::Tensor listHitTypePlanarTensor =
-        torch::from_blob(listHitTypePlanar.data(), {planarHitIndex}, torch::kFloat32);
-
-    torch::Tensor listPlanarHitIndices_tensor =
-        torch::from_blob(listPlanarHitIndices.data(), {planarHitIndex, 2}, torch::kInt64);
-
-    /// Processing hits from gaseous detectors
-    std::vector<int64_t> listHitTypeWire;
-    int wireHitIndex = 0;
-    std::vector<int64_t> listWireHitIndices;
-    int wireHitCollectionIndex = 0;
-    for (const auto& inputHitCollection : inputWireHitCollections) {
-      int wireHitSubCollectionIndex = 0;
-      for (const auto& inputHit : *inputHitCollection) {
-
-        // position along the wire, wire direction and drift distance
-        edm4hep::Vector3d wirePos = inputHit.getPosition();
-        TVector3 wirePosVector(static_cast<float>(wirePos.x), static_cast<float>(wirePos.y),
-                               static_cast<float>(wirePos.z));
-
-        double distanceToWire = inputHit.getDistanceToWire();
-        double wireAzimuthalAngle = inputHit.getWireAzimuthalAngle();
-        double wireStereoAngle = inputHit.getWireStereoAngle();
-
-        // Direction of the wire: z'
-        TVector3 direction(0, 0, 1);
-        direction.RotateX(wireStereoAngle);
-        direction.RotateZ(wireAzimuthalAngle);
-
-        TVector3 zPrime;
-        zPrime = direction.Unit();
-
-        // x' axis, orthogonal to z'
-        TVector3 xPrime(1.0, 0.0, -direction.X() / direction.Z());
-        xPrime = xPrime.Unit();
-
-        // y' axis = z' × x'
-        TVector3 yPrime = zPrime.Cross(xPrime);
-        yPrime = yPrime.Unit();
-
-        // Define the local left/right positions
-        TVector3 leftLocalPos(-distanceToWire, 0.0, 0.0);
-        TVector3 rightLocalPos(distanceToWire, 0.0, 0.0);
-
-        // Transform to global
-        TVector3 leftGlobalPos =
-            xPrime * leftLocalPos.X() + yPrime * leftLocalPos.Y() + zPrime * leftLocalPos.Z() + wirePosVector;
-        TVector3 rightGlobalPos =
-            xPrime * rightLocalPos.X() + yPrime * rightLocalPos.Y() + zPrime * rightLocalPos.Z() + wirePosVector;
-
-        // Add the 3D position of the left hit to the global input list.
-        listGlobalInputs.push_back(leftGlobalPos.X());
-        listGlobalInputs.push_back(leftGlobalPos.Y());
-        listGlobalInputs.push_back(leftGlobalPos.Z());
-
-        // Add the difference between the right and left hit positions to the global input list.
-        listGlobalInputs.push_back(0.0);
-        listGlobalInputs.push_back(rightGlobalPos.X() - leftGlobalPos.X());
-        listGlobalInputs.push_back(rightGlobalPos.Y() - leftGlobalPos.Y());
-        listGlobalInputs.push_back(rightGlobalPos.Z() - leftGlobalPos.Z());
-
-        listHitTypeWire.push_back(globalHitIndex);
-
-        listWireHitIndices.push_back(wireHitCollectionIndex);
-        listWireHitIndices.push_back(wireHitSubCollectionIndex);
-
-        globalHitIndex += 1;
-        wireHitIndex += 1;
-        wireHitSubCollectionIndex += 1;
-      }
-    }
-    // Convert ListHitType_CDC to a Torch tensor for use in PyTorch models.
-    torch::Tensor listHitTypeWireTensor = torch::from_blob(listHitTypeWire.data(), {wireHitIndex}, torch::kFloat32);
-
-    torch::Tensor listWireHitIndicesTensor =
-        torch::from_blob(listWireHitIndices.data(), {wireHitIndex, 2}, torch::kInt64);
-
-    torch::Tensor planarTypeTensor = torch::zeros({planarHitIndex, 1}, torch::kInt64);
-    torch::Tensor wireTypeTensor = torch::ones({wireHitIndex, 1}, torch::kInt64);
-
-    torch::Tensor planarTypeIndexTensor = torch::cat({planarTypeTensor, listPlanarHitIndices_tensor}, 1);
-    torch::Tensor wireTypeIndexTensor = torch::cat({wireTypeTensor, listWireHitIndicesTensor}, 1);
-    torch::Tensor listHitIndicesGlobal = torch::cat({planarTypeIndexTensor, wireTypeIndexTensor}, 0);
-
-    //////////////////////////////////
-    ////////// TRACK FINDER //////////
-    //////////////////////////////////
-
-    // Create a new TrackCollection and TrackerHit3DCollection for storing the output tracks and hits
     edm4hep::TrackCollection outputTracks;
-    constexpr int kMaxHits = 20000;
-    if (globalHitIndex > 0 && globalHitIndex < kMaxHits) {
 
-      ///////////////////////////////
-      ////////// GATR STEP //////////
-      ///////////////////////////////
+    HitBatch batch;
+    reserveBatch(inputPlanarHitCollections, inputWireHitCollections, batch);
+    appendPlanarHits(inputPlanarHitCollections, batch);
+    appendWireHits(inputWireHitCollections, batch);
 
-      // Calculate the total size of the input tensor, based on the number of hits (it) and the
-      // number of features per hit (7: x, y, z, and four placeholders).
-      size_t inputTensorTotalSize = globalHitIndex * 7;
-      std::vector<int64_t> inputTensorShape = {globalHitIndex, 7};
-
-      // Create a vector to store the input tensors that will be fed into the ONNX model.
-      std::vector<Ort::Value> inputModelTensors;
-      inputModelTensors.emplace_back(Ort::Value::CreateTensor<float>(
-          *m_fInfo, listGlobalInputs.data(), inputTensorTotalSize, inputTensorShape.data(), inputTensorShape.size()));
-
-      // Run the ONNX inference session with the provided input tensor.
-      auto outputModelTensors = m_fSession->Run(Ort::RunOptions{nullptr}, m_fInames.data(), inputModelTensors.data(),
-                                                m_fInames.size(), m_fOnames.data(), m_fOnames.size());
-      float* floatarr = outputModelTensors.front().GetTensorMutableData<float>();
-      std::vector<float> outputModelVector(floatarr, floatarr + globalHitIndex * 4);
-
-      /////////////////////////////////////
-      ////////// CLUSTERING STEP //////////
-      /////////////////////////////////////
-
-      auto clusteringIndeces = get_clustering(outputModelVector, globalHitIndex, m_tbeta, m_td);
-      torch::Tensor uniqueTensor;
-      torch::Tensor inverseIndices;
-      std::tie(uniqueTensor, inverseIndices) = at::_unique(clusteringIndeces, true, true);
-
-      /////////////////////////////////
-      ////////// OUTPUT STEP //////////
-      /////////////////////////////////
-
-      // NB: In this implementation, for each track the flag "type" is defined as follows:
-      //     0 : unclustered
-      //     1 : clustered
-      //
-      // Here, "unclustered" refers to hits that are not associated with any reconstructed track.
-      // This may occur either because the hit originates from background activity or due to
-      // an inefficiency/mistake in the track-finding algorithm.
-
-      // Get the total number of unique tracks based on the uniqueTensor size
-      int64_t numTracks = uniqueTensor.numel();
-      bool has_zero = (uniqueTensor == 0).any().item<bool>();
-      if (!has_zero) {
-        auto outputTrack = outputTracks.create();
-        outputTrack.setType(0);
-      }
-
-      // Loop through each unique track ID
-      for (int i = 0; i < numTracks; ++i) {
-
-        // Create a new track in the output collection and set its type to the current track ID
-        auto outputTrack = outputTracks.create();
-        outputTrack.setType(1);
-
-        // Select all hits belonging to the current track
-        auto idTrack = uniqueTensor.index({i});
-        torch::Tensor mask = (clusteringIndeces == idTrack);
-        torch::Tensor indices = torch::nonzero(mask).flatten();
-
-        auto listHitIndicesGlobalView = listHitIndicesGlobal.accessor<int64_t, 2>();
-        auto indicesView = indices.accessor<int64_t, 1>();
-
-        for (int64_t j = 0; j < indices.size(0); ++j) {
-          int64_t row = indicesView[j];
-          int64_t type = listHitIndicesGlobalView[row][0];
-          int64_t idx1 = listHitIndicesGlobalView[row][1];
-          int64_t idx2 = listHitIndicesGlobalView[row][2];
-
-          if (type == 0) {
-            // planar hit
-            auto planarCollection = inputPlanarHitCollections[idx1];
-            auto hit = planarCollection->at(idx2);
-            outputTrack.addToTrackerHits(hit);
-
-          } else {
-            // wire hit
-            auto wireCollection = inputWireHitCollections[idx1];
-            auto hit = wireCollection->at(idx2);
-            outputTrack.addToTrackerHits(hit);
-          }
-        }
-      }
-
-      inverseIndices.reset();
-      uniqueTensor.reset();
-      clusteringIndeces.reset();
-
-      inputModelTensors.clear();
-      outputModelTensors.clear();
+    if (batch.nHits == 0) {
+      return std::make_tuple(std::move(outputTracks));
     }
 
-    listHitTypePlanarTensor.reset();
-    listPlanarHitIndices_tensor.reset();
-    listHitTypeWireTensor.reset();
-    listWireHitIndicesTensor.reset();
+    if (batch.nHits > kMaxHits) {
+      warning() << "Event " << eventNumber << " has " << batch.nHits << " hits, exceeding the configured limit of "
+                << kMaxHits << "; skipping." << endmsg;
+      return std::make_tuple(std::move(outputTracks));
+    }
 
-    std::vector<int64_t>().swap(listHitTypePlanar);
-    std::vector<int64_t>().swap(listPlanarHitIndices);
-    std::vector<int64_t>().swap(listHitTypeWire);
-    std::vector<int64_t>().swap(listWireHitIndices);
+    const std::vector<float> modelOutput = runInference(batch.features, batch.nHits);
+    const torch::Tensor clusterIds = get_clustering(modelOutput, batch.nHits, m_tbeta, m_td);
 
-    // Return the output collections as a tuple
+    buildTracks(clusterIds, batch, inputPlanarHitCollections, inputWireHitCollections, outputTracks);
+
     return std::make_tuple(std::move(outputTracks));
   }
 
   StatusCode finalize() override {
-
     info() << "Run report:" << endmsg;
-    info() << "Number of analysed events: " << m_indexCounter << endmsg;
-    info() << "----------------\n" << endmsg;
-
+    info() << "Number of analysed events: " << m_eventCounter.load(std::memory_order_relaxed) << endmsg;
+    info() << "----------------" << endmsg;
     return StatusCode::SUCCESS;
   }
 
-public:
-  mutable int m_indexCounter = 0;
-
 private:
-  // Pointer to the ONNX environment.
-  // This object manages the global state of the ONNX runtime, such as logging and threading.
-  std::unique_ptr<Ort::Env> m_fEnv;
+  enum class HitType : std::uint8_t { Planar = 0, Wire = 1 };
 
-  // Pointer to the ONNX inference session.
-  // This session is used to execute the model for inference.
-  std::unique_ptr<Ort::Session> m_fSession;
+  /**
+   * @struct HitBatch
+   * @brief Flattened per-event feature buffer and source-hit bookkeeping.
+   */
+  struct HitBatch {
+    std::vector<float> features;                // Seven float features per hit.
+    std::vector<HitType> hitTypes;              // Original hit kind.
+    std::vector<std::size_t> collectionIndices; // Source collection index.
+    std::vector<std::size_t> hitIndices;        // Index within the source collection.
+    std::size_t nHits = 0;                      // Total number of flattened hits.
+  };
 
-  // ONNX session options.
-  Ort::SessionOptions m_fSessionOptions;
+  /**
+   * @brief Reserve enough storage for all hits in the event.
+   *
+   * Reserving all parallel arrays once avoids repeated reallocations and keeps
+   * their capacities consistent.
+   *
+   * @param planarCollections Planar hit collections.
+   * @param wireCollections Wire hit collections.
+   * @param batch Batch whose buffers will be reserved.
+   */
+  static void reserveBatch(const std::vector<const edm4hep::TrackerHitPlaneCollection*>& planarCollections,
+                           const std::vector<const edm4hep::SenseWireHitCollection*>& wireCollections,
+                           HitBatch& batch) {
+    std::size_t totalHits = 0;
+    for (const auto* collection : planarCollections) {
+      if (collection != nullptr) {
+        totalHits += collection->size();
+      }
+    }
+    for (const auto* collection : wireCollections) {
+      if (collection != nullptr) {
+        totalHits += collection->size();
+      }
+    }
 
-  // ONNX memory info.
-  // This object provides information about memory allocation and is used during the creation of
-  // ONNX tensors. It specifies the memory type and device (e.g., CPU, GPU).
-  std::unique_ptr<Ort::MemoryInfo> m_fInfo;
+    if (totalHits > static_cast<std::size_t>(kMaxHits)) {
+      // Reserve only up to the accepted event size. The event will be rejected
+      // after flattening reaches the configured limit.
+      totalHits = static_cast<std::size_t>(kMaxHits) + 1U;
+    }
 
-  // Stores the input and output names for the ONNX model.
-  // These vectors contain the names of the inputs (fInames) and outputs (fOnames) that the model expects.
-  std::vector<const char*> m_fInames;
-  std::vector<const char*> m_fOnames;
+    batch.features.reserve(totalHits * kFeatureCount);
+    batch.hitTypes.reserve(totalHits);
+    batch.collectionIndices.reserve(totalHits);
+    batch.hitIndices.reserve(totalHits);
+  }
 
-  // Property to specify the path to the ONNX model file.
-  // This is a configurable property that defines the location of the ONNX model file on the filesystem.
-  Gaudi::Property<std::string> m_modelPath{this, "ModelPath", "", "ModelPath"};
+  /**
+   * @brief Append planar tracker hits to the flattened model input.
+   *
+   * A planar hit is encoded as `(x, y, z, 1, 0, 0, 0)`.
+   *
+   * @param collections Input planar hit collections.
+   * @param batch Destination event batch.
+   */
+  static void appendPlanarHits(const std::vector<const edm4hep::TrackerHitPlaneCollection*>& collections,
+                               HitBatch& batch) {
+    for (std::size_t collectionIndex = 0; collectionIndex < collections.size(); ++collectionIndex) {
+      const auto* collection = collections[collectionIndex];
+      if (collection == nullptr) {
+        throw std::invalid_argument("Null planar-hit collection pointer");
+      }
 
-  // Properties of the clustering step.
-  Gaudi::Property<double> m_tbeta{this, "Tbeta", 0.6,
-                                  "tbeta: threshold used to identify core points in clusters (tracks)"};
-  Gaudi::Property<double> m_td{this, "Td", 0.3,
-                               "td: radius around a core point used to assign nearby hits to its cluster"};
+      for (std::size_t hitIndex = 0; hitIndex < collection->size(); ++hitIndex) {
+        if (batch.nHits > static_cast<std::size_t>(kMaxHits)) {
+          return;
+        }
+
+        const auto hit = collection->at(hitIndex);
+        const auto position = hit.getPosition();
+
+        batch.features.insert(batch.features.end(), {static_cast<float>(position.x), static_cast<float>(position.y),
+                                                     static_cast<float>(position.z), 1.0F, 0.0F, 0.0F, 0.0F});
+        batch.hitTypes.push_back(HitType::Planar);
+        batch.collectionIndices.push_back(collectionIndex);
+        batch.hitIndices.push_back(hitIndex);
+        ++batch.nHits;
+      }
+    }
+  }
+
+  /**
+   * @brief Append wire hits to the flattened model input.
+   *
+   * Each drift-chamber hit is represented by one left/right ambiguity segment:
+   * the first three features contain the left point, the fourth identifies a
+   * wire hit, and the final three contain the vector from left to right.
+   *
+   * @param collections Input wire-hit collections.
+   * @param batch Destination event batch.
+   */
+  static void appendWireHits(const std::vector<const edm4hep::SenseWireHitCollection*>& collections, HitBatch& batch) {
+    for (std::size_t collectionIndex = 0; collectionIndex < collections.size(); ++collectionIndex) {
+      const auto* collection = collections[collectionIndex];
+      if (collection == nullptr) {
+        throw std::invalid_argument("Null wire-hit collection pointer");
+      }
+
+      for (std::size_t hitIndex = 0; hitIndex < collection->size(); ++hitIndex) {
+        if (batch.nHits > static_cast<std::size_t>(kMaxHits)) {
+          return;
+        }
+
+        const auto hit = collection->at(hitIndex);
+        const edm4hep::Vector3d wirePosition = hit.getPosition();
+        const TVector3 wirePositionVector(wirePosition.x, wirePosition.y, wirePosition.z);
+
+        const double distanceToWire = hit.getDistanceToWire();
+        const double azimuthalAngle = hit.getWireAzimuthalAngle();
+        const double stereoAngle = hit.getWireStereoAngle();
+
+        if (!std::isfinite(distanceToWire) || !std::isfinite(azimuthalAngle) || !std::isfinite(stereoAngle)) {
+          throw std::runtime_error("Wire hit contains non-finite geometry values");
+        }
+
+        TVector3 zPrime, xPrime, yPrime;
+        const double dx = std::sin(stereoAngle) * std::sin(azimuthalAngle);
+        const double dy = -std::sin(stereoAngle) * std::cos(azimuthalAngle);
+        const double dz = std::cos(stereoAngle);
+        zPrime = TVector3(dx, dy, dz).Unit();
+        xPrime = TVector3(1.0, 0.0, -dx / dz).Unit(); // x' = normalize([1, 0, -dx/dz])
+        yPrime = zPrime.Cross(xPrime).Unit();         // y' = z' x x'
+
+        const TVector3 leftLocal(-distanceToWire, 0.0, 0.0);
+        const TVector3 rightLocal(distanceToWire, 0.0, 0.0);
+
+        const TVector3 leftGlobal =
+            xPrime * leftLocal.X() + yPrime * leftLocal.Y() + zPrime * leftLocal.Z() + wirePositionVector;
+        const TVector3 rightGlobal =
+            xPrime * rightLocal.X() + yPrime * rightLocal.Y() + zPrime * rightLocal.Z() + wirePositionVector;
+        const TVector3 ambiguityVector = rightGlobal - leftGlobal;
+
+        batch.features.insert(batch.features.end(),
+                              {static_cast<float>(leftGlobal.X()), static_cast<float>(leftGlobal.Y()),
+                               static_cast<float>(leftGlobal.Z()), 0.0F, static_cast<float>(ambiguityVector.X()),
+                               static_cast<float>(ambiguityVector.Y()), static_cast<float>(ambiguityVector.Z())});
+        batch.hitTypes.push_back(HitType::Wire);
+        batch.collectionIndices.push_back(collectionIndex);
+        batch.hitIndices.push_back(hitIndex);
+        ++batch.nHits;
+      }
+    }
+  }
+
+  /**
+   * @brief Run the ONNX model for one event.
+   *
+   * @param features Flattened input feature buffer; must contain `nHits * 7`
+   *        float values.
+   * @param nHits Number of hits represented by the input buffer.
+   * @return Flat model output containing four float values per hit.
+   * @throws std::logic_error if the session is not initialized.
+   * @throws std::runtime_error if the input or output shape is invalid.
+   */
+  std::vector<float> runInference(std::vector<float>& features, std::size_t nHits) const {
+
+    if (m_session == nullptr || m_memoryInfo == nullptr) {
+      throw std::logic_error("ONNX Runtime session is not initialized");
+    }
+    if (features.size() != nHits * kFeatureCount) {
+      throw std::runtime_error("Feature buffer size does not match nHits * 7");
+    }
+    if (nHits > static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max())) {
+      throw std::overflow_error("Hit count cannot be represented by the ONNX tensor shape");
+    }
+
+    const std::vector<std::int64_t> inputShape = {static_cast<std::int64_t>(nHits),
+                                                  static_cast<std::int64_t>(kFeatureCount)};
+
+    Ort::Value input = Ort::Value::CreateTensor<float>(*m_memoryInfo, features.data(), features.size(),
+                                                       inputShape.data(), inputShape.size());
+
+    const char* inputNames[] = {m_inputName.c_str()};
+    const char* outputNames[] = {m_outputName.c_str()};
+    auto outputs = m_session->Run(Ort::RunOptions{nullptr}, inputNames, &input, 1, outputNames, 1);
+
+    if (outputs.size() != 1 || !outputs.front().IsTensor()) {
+      throw std::runtime_error("ONNX model did not return exactly one tensor output");
+    }
+
+    const auto outputInfo = outputs.front().GetTensorTypeAndShapeInfo();
+    const std::size_t outputElementCount = outputInfo.GetElementCount();
+    const std::size_t expectedElementCount = nHits * kOutputValuesPerHit;
+    if (outputElementCount != expectedElementCount) {
+      throw std::runtime_error("Unexpected ONNX output size: expected four values per hit");
+    }
+
+    const float* outputData = outputs.front().GetTensorData<float>();
+    return {outputData, outputData + outputElementCount};
+  }
+
+  /**
+   * @brief Group hits by cluster identifier and emit one track per cluster.
+   *
+   * @param clusterIds One-dimensional tensor with one cluster identifier per hit.
+   * @param batch Flattened hit metadata used to recover source EDM objects.
+   * @param planarCollections Original planar hit collections.
+   * @param wireCollections Original wire hit collections.
+   * @param outputTracks Destination track collection.
+   */
+  static void buildTracks(const torch::Tensor& clusterIds, const HitBatch& batch,
+                          const std::vector<const edm4hep::TrackerHitPlaneCollection*>& planarCollections,
+                          const std::vector<const edm4hep::SenseWireHitCollection*>& wireCollections,
+                          edm4hep::TrackCollection& outputTracks) {
+    if (!clusterIds.defined()) {
+      throw std::runtime_error("Clustering returned an undefined tensor");
+    }
+
+    const torch::Tensor ids = clusterIds.to(torch::kCPU).to(torch::kInt64).contiguous().view({-1});
+    if (static_cast<std::size_t>(ids.numel()) != batch.nHits) {
+      throw std::runtime_error("Cluster-id count does not match the number of input hits");
+    }
+
+    const std::int64_t nHits = ids.numel();
+    if (nHits == 0) {
+      return;
+    }
+
+    const torch::Tensor order = torch::argsort(ids);
+    const torch::Tensor sortedIds = ids.index_select(0, order);
+    const auto orderAccessor = order.accessor<std::int64_t, 1>();
+    const auto sortedIdsAccessor = sortedIds.accessor<std::int64_t, 1>();
+
+    std::int64_t clusterBegin = 0;
+    while (clusterBegin < nHits) {
+      std::int64_t clusterEnd = clusterBegin + 1;
+      while (clusterEnd < nHits && sortedIdsAccessor[clusterEnd] == sortedIdsAccessor[clusterBegin]) {
+        ++clusterEnd;
+      }
+
+      const std::int64_t clusterId = sortedIdsAccessor[clusterBegin];
+      if (clusterId > 0) {
+
+        auto outputTrack = outputTracks.create();
+        outputTrack.setType(1);
+
+        for (std::int64_t index = clusterBegin; index < clusterEnd; ++index) {
+          const std::size_t row = static_cast<std::size_t>(orderAccessor[index]);
+          const std::size_t collectionIndex = batch.collectionIndices[row];
+          const std::size_t hitIndex = batch.hitIndices[row];
+
+          if (batch.hitTypes[row] == HitType::Planar) {
+            outputTrack.addToTrackerHits(planarCollections[collectionIndex]->at(hitIndex));
+          } else {
+            outputTrack.addToTrackerHits(wireCollections[collectionIndex]->at(hitIndex));
+          }
+        }
+      }
+
+      clusterBegin = clusterEnd;
+    }
+  }
+
+  static constexpr std::size_t kFeatureCount = 7;
+  static constexpr std::size_t kOutputValuesPerHit = 4;
+  static constexpr std::size_t kMaxHits = 20000;
+
+  mutable std::atomic<std::uint64_t> m_eventCounter{0}; // Thread-safe processed-event counter.
+
+  std::unique_ptr<Ort::Env> m_environment;       // ONNX Runtime environment.
+  std::unique_ptr<Ort::Session> m_session;       // ONNX inference session.
+  Ort::SessionOptions m_sessionOptions;          // ONNX session configuration.
+  std::unique_ptr<Ort::MemoryInfo> m_memoryInfo; // CPU tensor-memory descriptor.
+  std::string m_inputName;                       // Owned ONNX input name.
+  std::string m_outputName;                      // Owned ONNX output name.
+
+  Gaudi::Property<std::string> m_modelPath{this, "ModelPath", "", "Path to the ONNX model file"};
+  Gaudi::Property<double> m_tbeta{this, "Tbeta", 0.6, "Threshold used to identify cluster core points"};
+  Gaudi::Property<double> m_td{this, "Td", 0.3, "Radius used to assign nearby hits to a cluster core"};
 };
 
 DECLARE_COMPONENT(GGTFTrackFinder)

--- a/Tracking/components/GenfitTrackFitter.cpp
+++ b/Tracking/components/GenfitTrackFitter.cpp
@@ -655,8 +655,7 @@ private:
                                     m_omega_factor.value(), m_z0_factor.value(), m_sigma_tanLambda.value());
 
     auto track_init = track_interface.GetInitialization();
-    const bool showDebugOutput =
-        m_printoutLevel == uint(MSG::DEBUG) || m_printoutLevel == uint(MSG::VERBOSE);
+    const bool showDebugOutput = m_printoutLevel == uint(MSG::DEBUG) || m_printoutLevel == uint(MSG::VERBOSE);
 
     debug() << "Track " << num_tracks_event << " with " << track.getTrackerHits().size()
             << " hits: initial seed for track fit:" << endmsg;

--- a/Tracking/components/GenfitTrackFitter.cpp
+++ b/Tracking/components/GenfitTrackFitter.cpp
@@ -306,8 +306,9 @@ struct GenfitTrackFitter final
   operator()(const edm4hep::TrackCollection& tracks_input) const override {
 
     debug() << "Event number: " << event_counter++ << endmsg;
+    num_tracks_event = 0;
 
-    // This collection stores the output of the fit
+    // These collections store the output of the fit
     edm4hep::TrackCollection FittedTracks;
     edm4hep::TrackCollection FittedTracksWithFilteredHits;
     edm4hep::TrackerHitPlaneCollection FittedHits;
@@ -315,21 +316,22 @@ struct GenfitTrackFitter final
     // Loop over the tracks created by the pattern recognition step
     for (const auto& track : tracks_input) {
 
-      num_tracks += 1;
+      num_tracks++;
+      num_tracks_event++;
 
       // Skip unmatched tracks if the option is enabled
-      // Consider unmatched tracks those with type = 0
       if (m_ListOfTypesToSkip.size() > 0 && std::find(m_ListOfTypesToSkip.begin(), m_ListOfTypesToSkip.end(),
                                                       track.getType()) != m_ListOfTypesToSkip.end()) {
         num_skip += 1;
-        warning() << "Skipping track " << num_tracks - 1 << " with type " << track.getType() << "\n" << endmsg;
-        continue; // skip unmatched tracks
+        debug() << "Skipping track " << num_tracks_event << " with type " << track.getType() << "\n" << endmsg;
+        continue;
       }
 
+      // skip tracks with less then 3 hits (seed initialization needs 3 hits)
       if (track.getTrackerHits().size() < 3) {
         num_skip += 1;
-        warning() << "Track " << num_tracks - 1 << ": less than 3 hits, skipping fit.\n" << endmsg;
-        continue; // skip tracks with less then 3 hits (seed initialization needs 3 hits)
+        debug() << "Track " << num_tracks_event << ": less than 3 hits, skipping fit.\n" << endmsg;
+        continue;
       }
 
       num_processed_tracks += 1;
@@ -342,10 +344,11 @@ struct GenfitTrackFitter final
 
       } else {
 
-        int winning_hypothesis = FindBestHypothesis(track, false);
+        int winning_hypothesis = FindBestHypothesis(track, FittedHits, false);
 
         if (winning_hypothesis == -1) {
-          debug() << "Track " << num_tracks - 1 << ": fit failed for all hypotheses, trying with less hits." << endmsg;
+          debug() << "Track " << num_tracks_event << ": fit failed for all hypotheses, trying with less hits."
+                  << endmsg;
         } else {
 
           isSuccess = 1;
@@ -365,7 +368,7 @@ struct GenfitTrackFitter final
           if (!isSuccess) {
 
             number_failures += 1;
-            debug() << "Track " << num_tracks - 1 << ": fit failed for single evaluation hypothesis, skipping track."
+            debug() << "Track " << num_tracks_event << ": fit failed for single evaluation hypothesis, skipping track."
                     << endmsg;
             auto failedTrack = FittedTracks.create();
             auto failedFittedTrack = FittedTracksWithFilteredHits.create();
@@ -381,11 +384,11 @@ struct GenfitTrackFitter final
 
         } else {
 
-          int winning_hypothesis = FindBestHypothesis(track, true);
+          int winning_hypothesis = FindBestHypothesis(track, FittedHits, true);
 
           if (winning_hypothesis == -1) {
 
-            debug() << "Track " << num_tracks - 1 << ": fit failed for all hypotheses." << endmsg;
+            debug() << "Track " << num_tracks_event << ": fit failed for all hypotheses." << endmsg;
             number_failures += 1;
             auto failedTrack = FittedTracks.create();
             auto failedFittedTrack = FittedTracksWithFilteredHits.create();
@@ -431,20 +434,27 @@ public:
 
   // Num_tracks = num_processed_tracks + num_skip
   mutable int num_tracks = 0;           // Total number of tracks seen (including skipped ones)
+  mutable int num_tracks_event = 0;     // Total number of tracks seen in one event (including skipped ones)
   mutable int num_skip = 0;             // Number of tracks skipped (e.g. failing pre-selection)
   mutable int num_processed_tracks = 0; // Number of tracks actually processed (i.e. not skipped)
   mutable int number_failures = 0;      // Number of track fits that failed
 
 private:
-  // ====================== Debug & Printout ======================
+  //////////////////////
+  // Debug & Printout //
+  //////////////////////
+
   // Debug level for track fitting and initialization printouts
   // 0       : no printouts
-  // INFO    : prints fit results
-  // DEBUG   : prints fit results + initial track parameters + track states
-  // VERBOSE : prints detailed internal fit information
+  // INFO    : prints the final fit summary
+  // DEBUG   : INFO + initial track parameters, measurements, track states, and fit failures
+  // VERBOSE : DEBUG + detailed internal fitter information
   uint m_printoutLevel;
 
-  // ====================== Geometry & Detector ======================
+  /////////////////////////
+  // Geometry & Detector //
+  /////////////////////////
+
   ServiceHandle<IGeoSvc> m_geoSvc{this, "GeoSvc", "GeoSvc", "Detector geometry service"};
   dd4hep::Detector* m_detector{nullptr}; // Detector instance
 
@@ -454,14 +464,14 @@ private:
   GenfitInterface::GenfitMaterialInterface* m_geoMaterial;
 
   dd4hep::rec::SurfaceManager* m_surfMan;
-  dd4hep::rec::WireTracker_info_struct* m_wire_info;
-  dd4hep::DDSegmentation::BitFieldCoder* m_dc_decoder;
+  dd4hep::rec::WireTracker_info_struct* m_wire_info{nullptr};
+  dd4hep::DDSegmentation::BitFieldCoder* m_dc_decoder{nullptr};
 
   Gaudi::Property<std::string> m_WireTracker_name{
       this, "WireTrackerName", "DCH_v2",
       "WireTrackerName in the detector description (used to retrieve Wire Tracker geometry and material information)"};
 
-  // ====================== ECAL Geometry Parameters ======================
+  // ECAL Geometry Parameters
   double m_eCalBarrelInnerR;
   double m_eCalBarrelMaxZ;
   double m_eCalEndCapInnerR;
@@ -469,7 +479,9 @@ private:
   double m_eCalEndCapInnerZ;
   double m_eCalEndCapOuterZ;
 
-  // ====================== Fitter Settings ======================
+  /////////////////////
+  // Fitter Settings //
+  /////////////////////
 
   Gaudi::Property<bool> m_useBrems{this, "UseBrems", false, "Include Bremsstrahlung energy loss and noise in the fit"};
 
@@ -487,7 +499,10 @@ private:
                                     "Number of steps in the annealing schedule (if m_Fitter_type == 'DAF') "
                                     "[https://indico.cern.ch/event/258092/papers/1588579/files/4253-genfit.pdf]"};
 
-  // ====================== Track Initialization ======================
+  //////////////////////////
+  // Track Initialization //
+  //////////////////////////
+
   Gaudi::Property<std::vector<int>> m_particleHypothesis{
       this,
       "ParticleHypothesisList",
@@ -519,7 +534,7 @@ private:
   Gaudi::Property<double> m_z0_factor{
       this, "Z0Factor", 0.1,
       "Scaling factor for z0 uncertainty for the initial covariance matrix when InitializationType = 0,1,3."
-      "The actual sigma_z0 is computed as Z0Factor * |z0 (in cm)|"};
+      "The actual sigma_z0 is computed as Z0Factor * |z0 (in mm)|"};
   Gaudi::Property<double> m_sigma_tanLambda{
       this, "Sigma_tanLambda", 0.1,
       "Initial uncertainty on tanLambda for the initial covariance matrix when InitializationType = 0,1,3."};
@@ -543,7 +558,10 @@ private:
       this, "SmoothWindow", 5,
       "Number of hits used for smoothing before computing the first derivative in track initialization"};
 
-  // ====================== Track Filtering & Evaluation ======================
+  ////////////////////////////////////
+  // Track Filtering and Evaluation //
+  ////////////////////////////////////
+
   Gaudi::Property<bool> m_skipTrackOrdering{this, "SkipTrackOrdering", false, "Skip hit ordering before fitting"};
 
   Gaudi::Property<std::vector<int>> m_ListOfTypesToSkip{
@@ -567,7 +585,10 @@ private:
       "and the corresponding track states are stored in the output track."
       "This is applied only if a non-zero magnetic field (Bz > 0) is found at the last hit position."};
 
-  // ====================== Track Classification ======================
+  //////////////////////////
+  // Track Classification //
+  //////////////////////////
+
   Gaudi::Property<double> m_RadialThresholdPromptTrack{
       this, "RadialThresholdPromptTrack", 100.,
       "Radius [mm] defining a spherical region centered at {0,0,0}. "
@@ -577,7 +598,9 @@ private:
       "using the PCA "
       "of the first hit."};
 
-  // ====================== Fit Helpers ======================
+  /////////////////
+  // Fit Helpers //
+  /////////////////
 
   /**
    * @brief Process and fit a reconstructed track using Genfit, with optional hit filtering
@@ -624,15 +647,18 @@ private:
 
     TVector3 Init_momentum(m_init_momentum.value()[0], m_init_momentum.value()[1], m_init_momentum.value()[2]);
 
-    track_interface.InitializeTrack(m_RadialThresholdPromptTrack.value(), m_useFirstHitAsReference, LimitHits,
+    double RadialThresholdPromptTrack_cm = m_RadialThresholdPromptTrack.value() * dd4hep::mm;
+
+    track_interface.InitializeTrack(RadialThresholdPromptTrack_cm, m_useFirstHitAsReference, LimitHits,
                                     m_initializationType, m_trackStateLocation.value(), Init_position, Init_momentum,
-                                    m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value() * dd4hep::mm,
-                                    m_sigma_phi.value(), m_omega_factor.value(), m_z0_factor.value(),
-                                    m_sigma_tanLambda.value());
+                                    m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value(), m_sigma_phi.value(),
+                                    m_omega_factor.value(), m_z0_factor.value(), m_sigma_tanLambda.value());
 
     auto track_init = track_interface.GetInitialization();
+    const bool showDebugOutput =
+        m_printoutLevel == uint(MSG::DEBUG) || m_printoutLevel == uint(MSG::VERBOSE);
 
-    debug() << "Track " << num_tracks - 1 << " with " << track.getTrackerHits().size()
+    debug() << "Track " << num_tracks_event << " with " << track.getTrackerHits().size()
             << " hits: initial seed for track fit:" << endmsg;
 
     debug() << "  Initial position [mm]: (" << track_init.Position.X() / dd4hep::mm << ", "
@@ -644,22 +670,22 @@ private:
     debug() << "  Charge hypothesis: " << track_init.Charge << endmsg;
     debug() << "  Max hit for loopers: " << track_init.NumHits << endmsg;
 
-    if (m_printoutLevel == uint(MSG::DEBUG)) {
+    if (showDebugOutput) {
       debug() << "  Initial covariance matrix:" << endmsg;
       track_init.CovMatrix.Print();
     }
 
     debug() << endmsg;
 
-    int debug_track = (m_printoutLevel == uint(MSG::DEBUG)) ? 1 : 0;
+    int debug_track = showDebugOutput ? 1 : 0;
 
     track_interface.CreateGenFitTrack(particleHypothesis, debug_track);
 
-    bool isFit = track_interface.Fit(m_Fitter_type.value(), m_printoutLevel, m_Beta_init, m_Beta_final, m_Beta_steps,
-                                     m_filterTrackHits);
+    bool isFit = track_interface.Fit(FittedHits, m_Fitter_type.value(), m_printoutLevel, m_Beta_init, m_Beta_final,
+                                     m_Beta_steps, m_filterTrackHits);
 
     if (!isFit) {
-      debug() << "Track fit FAILED for track " << num_tracks - 1 << endmsg;
+      debug() << "Track fit FAILED for track " << num_tracks_event << endmsg;
       return false;
     }
 
@@ -681,7 +707,7 @@ private:
                                             m_eCalBarrelMaxZ, m_eCalEndCapInnerR, m_eCalEndCapOuterR,
                                             m_eCalEndCapInnerZ);
 
-      if (m_printoutLevel == uint(MSG::DEBUG)) {
+      if (showDebugOutput) {
         auto trackStates = edm4hep_track.getTrackStates();
         edm4hep::TrackState trackStateCalo;
         for (const auto& ts : trackStates) {
@@ -716,7 +742,7 @@ private:
                                               m_eCalBarrelInnerR, m_eCalBarrelMaxZ, m_eCalEndCapInnerR,
                                               m_eCalEndCapOuterR, m_eCalEndCapInnerZ);
 
-        if (m_printoutLevel == uint(MSG::DEBUG)) {
+        if (showDebugOutput) {
           auto trackStates = edm4hep_track.getTrackStates();
           edm4hep::TrackState trackStateCalo;
           for (const auto& ts : trackStates) {
@@ -728,7 +754,6 @@ private:
         }
       }
 
-      FittedHits = std::move(track_interface.GetFittedHits());
       FittedTracksWithFilteredHits.push_back(edm4hep_track_with_fit);
     }
 
@@ -762,11 +787,15 @@ private:
    *       additional physics constraints or likelihood-based criteria.
    * @note All fits are performed with debug output disabled and without hit filtering.
    */
-  int FindBestHypothesis(const edm4hep::Track& track, bool LimitHits) const {
+  int FindBestHypothesis(const edm4hep::Track& track, edm4hep::TrackerHitPlaneCollection& fittedHits,
+                         bool LimitHits) const {
 
-    TVector3 Init_position(m_init_position.value()[0], m_init_position.value()[1], m_init_position.value()[2]);
+    TVector3 Init_position(m_init_position.value()[0] * dd4hep::mm, m_init_position.value()[1] * dd4hep::mm,
+                           m_init_position.value()[2] * dd4hep::mm);
 
     TVector3 Init_momentum(m_init_momentum.value()[0], m_init_momentum.value()[1], m_init_momentum.value()[2]);
+
+    double RadialThresholdPromptTrack_cm = m_RadialThresholdPromptTrack.value() * dd4hep::mm;
 
     int winning_hypothesis = -1;
     double winning_chi2_ndf = std::numeric_limits<double>::max();
@@ -776,15 +805,16 @@ private:
       GenfitInterface::GenfitTrack track_interface(track, m_skipTrackOrdering, m_wire_info, m_dc_decoder,
                                                    m_genfitField.get());
 
-      track_interface.InitializeTrack(m_RadialThresholdPromptTrack.value(), m_useFirstHitAsReference, LimitHits,
+      track_interface.InitializeTrack(RadialThresholdPromptTrack_cm, m_useFirstHitAsReference, LimitHits,
                                       m_initializationType, m_trackStateLocation.value(), Init_position, Init_momentum,
-                                      m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value() * dd4hep::mm,
+                                      m_epsilon.value(), m_smoothWindow.value(), m_sigma_d0.value(),
                                       m_sigma_phi.value(), m_omega_factor.value(), m_z0_factor.value(),
                                       m_sigma_tanLambda.value());
 
       track_interface.CreateGenFitTrack(pdgCode, 0);
 
-      bool isFit = track_interface.Fit(m_Fitter_type.value(), 0, m_Beta_init, m_Beta_final, m_Beta_steps, false);
+      bool isFit =
+          track_interface.Fit(fittedHits, m_Fitter_type.value(), 0, m_Beta_init, m_Beta_final, m_Beta_steps, false);
 
       if (!isFit)
         continue;

--- a/Tracking/include/genfit_interfaces/GenfitDebugLevel.h
+++ b/Tracking/include/genfit_interfaces/GenfitDebugLevel.h
@@ -18,9 +18,9 @@ protected:
 ErrorHandlerFunc_t previousRootErrorHandler = nullptr;
 
 void filteredRootErrorHandler(int level, Bool_t abort, const char* location, const char* message) {
-  const bool isNonPositiveDefiniteCholesky =
-      location != nullptr && message != nullptr && std::strstr(location, "TDecompChol::Decompose") != nullptr &&
-      std::strstr(message, "matrix not positive definite") != nullptr;
+  const bool isNonPositiveDefiniteCholesky = location != nullptr && message != nullptr &&
+                                             std::strstr(location, "TDecompChol::Decompose") != nullptr &&
+                                             std::strstr(message, "matrix not positive definite") != nullptr;
 
   if (isNonPositiveDefiniteCholesky) {
     return;

--- a/Tracking/include/genfit_interfaces/GenfitDebugLevel.h
+++ b/Tracking/include/genfit_interfaces/GenfitDebugLevel.h
@@ -1,0 +1,73 @@
+#ifndef GENFIT_DEBUG_LEVEL_H
+#define GENFIT_DEBUG_LEVEL_H
+
+#include <cstring>
+#include <streambuf>
+
+#include <IO.h>
+#include <TError.h>
+#include <TGeoManager.h>
+
+namespace {
+
+class NullStreamBuffer final : public std::streambuf {
+protected:
+  int_type overflow(int_type character) override { return traits_type::not_eof(character); }
+};
+
+ErrorHandlerFunc_t previousRootErrorHandler = nullptr;
+
+void filteredRootErrorHandler(int level, Bool_t abort, const char* location, const char* message) {
+  const bool isNonPositiveDefiniteCholesky =
+      location != nullptr && message != nullptr && std::strstr(location, "TDecompChol::Decompose") != nullptr &&
+      std::strstr(message, "matrix not positive definite") != nullptr;
+
+  if (isNonPositiveDefiniteCholesky) {
+    return;
+  }
+
+  if (previousRootErrorHandler != nullptr) {
+    previousRootErrorHandler(level, abort, location, message);
+  } else {
+    DefaultErrorHandler(level, abort, location, message);
+  }
+}
+
+class ScopedFitDiagnostics final {
+public:
+  explicit ScopedFitDiagnostics(bool suppress) : m_suppress(suppress) {
+    if (!m_suppress) {
+      return;
+    }
+
+    m_genfitErrorBuffer = genfit::errorOut.rdbuf(&m_sink);
+    m_genfitDebugBuffer = genfit::debugOut.rdbuf(&m_sink);
+    m_previousRootErrorHandler = SetErrorHandler(filteredRootErrorHandler);
+    previousRootErrorHandler = m_previousRootErrorHandler;
+  }
+
+  ~ScopedFitDiagnostics() {
+    if (!m_suppress) {
+      return;
+    }
+
+    SetErrorHandler(m_previousRootErrorHandler);
+    previousRootErrorHandler = nullptr;
+    genfit::errorOut.rdbuf(m_genfitErrorBuffer);
+    genfit::debugOut.rdbuf(m_genfitDebugBuffer);
+  }
+
+  ScopedFitDiagnostics(const ScopedFitDiagnostics&) = delete;
+  ScopedFitDiagnostics& operator=(const ScopedFitDiagnostics&) = delete;
+
+private:
+  bool m_suppress;
+  NullStreamBuffer m_sink;
+  std::streambuf* m_genfitErrorBuffer{nullptr};
+  std::streambuf* m_genfitDebugBuffer{nullptr};
+  ErrorHandlerFunc_t m_previousRootErrorHandler{nullptr};
+};
+
+} // namespace
+
+#endif // GENFIT_DEBUG_LEVEL_H

--- a/Tracking/include/genfit_interfaces/GenfitTrack.h
+++ b/Tracking/include/genfit_interfaces/GenfitTrack.h
@@ -98,16 +98,25 @@ public:
                        std::optional<double> sigma_z0, std::optional<double> sigma_tanLambda);
 
   void CreateGenFitTrack(int particle_hypotesis, int debug_lvl);
-  bool Fit(std::string FitterType, int debug_lvl, std::optional<double> Beta_init, std::optional<double> Beta_final,
-           std::optional<int> Beta_steps, std::optional<bool> FilterHits);
+  bool Fit(edm4hep::TrackerHitPlaneCollection& fittedHits, std::string FitterType, int debug_lvl,
+           std::optional<double> Beta_init, std::optional<double> Beta_final, std::optional<int> Beta_steps,
+           std::optional<bool> FilterHits);
 
   genfit::Track* GetTrack_genfit() { return m_genfitTrack; }
   genfit::AbsTrackRep* GetRep_genfit() { return m_genfitTrackRep; }
   edm4hep::MutableTrack& GetTrack_edm4hep() { return m_edm4hepTrack; }
   edm4hep::MutableTrack& GetTrackWithFit_edm4hep() { return m_trackWithFit; }
-  edm4hep::TrackerHitPlaneCollection& GetFittedHits() { return m_fittedHits; }
 
   int GetCharge() { return m_charge_hypothesis; }
+
+  static TMatrixDSym InitialCovarianceMatrixHelixToCartesian(const TMatrixDSym& helixCovariance,
+                                                             const TVector3& positionCm, const TVector3& momentumGeV,
+                                                             const TVector3& referencePointCm, int charge,
+                                                             double magneticFieldTesla);
+
+  TMatrixDSym CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6,
+                                               TVector3 Position_cm, TVector3 Momentum_gev, TVector3 RefPoint_cm,
+                                               int Charge, double Bz);
 
   void PrintTrack_init() {
 
@@ -142,13 +151,7 @@ private:
   void CheckInitialization();
   void OrderHits(const edm4hep::Track& track, bool skipTrackOrdering);
   void LimitNumberHits(double epsilon, int smoothWindow);
-
-  TMatrixDSym CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_helix, TVector3 Position_cm, TVector3 Momentum_gev,
-                                               TVector3 RefPoint_cm, int charge, double Bz);
-
-  TMatrixDSym CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_cartesian, // 6x6,
-                                               TVector3 Position_cm, TVector3 Momentum_gev, TVector3 RefPoint_cm,
-                                               int Charge, double Bz);
+  void SetVPPosition(TVector3 referencePoint) { m_VP_referencePoint = referencePoint; };
 
   TMatrixDSym ComputeInitialCovarianceMatrix(double Bz, int Charge, std::optional<double> sigma_d0,
                                              std::optional<double> sigma_phi, std::optional<double> sigma_omega,
@@ -156,7 +159,8 @@ private:
 
   HelperInitialization ComputeInitialParameters(double Bz);
 
-  edm4hep::TrackState UpdateTrackState(genfit::MeasuredStateOnPlane MeasuredState, int location);
+  edm4hep::TrackState UpdateTrackState(genfit::MeasuredStateOnPlane MeasuredState, TVector3 ReferencePoint,
+                                       int location);
 
   PCAInfoHelper PCAInfo(TVector3 position, TVector3 momentum, int charge, TVector3 refPoint, double Bz);
 
@@ -167,14 +171,17 @@ private:
   TVector3 m_momInit = TVector3(0., 0., 0.);
   TMatrixDSym m_covInit;
 
+  // Non-owning alias: ownership is transferred to m_genfitTrack when it is constructed.
   genfit::AbsTrackRep* m_genfitTrackRep = nullptr;
+  // Owns its TrackReps, TrackPoints, and measurements.
   genfit::Track* m_genfitTrack = nullptr;
 
   edm4hep::MutableTrack m_edm4hepTrack;
   edm4hep::MutableTrack m_trackWithFit;
-  edm4hep::TrackerHitPlaneCollection m_fittedHits;
 
   TVector3 m_VP_referencePoint{0., 0., 0.};
+  TVector3 m_FirstHit_referencePoint{0., 0., 0.};
+  TVector3 m_LastHit_referencePoint{0., 0., 0.};
 
   const dd4hep::rec::WireTracker_info_struct* m_wire_info;
   const dd4hep::DDSegmentation::BitFieldCoder* m_dc_decoder;

--- a/Tracking/src/genfit_interfaces/GenfitTrack.cpp
+++ b/Tracking/src/genfit_interfaces/GenfitTrack.cpp
@@ -19,6 +19,8 @@
 
 #include "GenfitTrack.h"
 
+#include "GenfitDebugLevel.h"
+
 namespace GenfitInterface {
 
 GenfitTrack::GenfitTrack(const edm4hep::Track& track, const bool skipTrackOrdering,
@@ -26,9 +28,7 @@ GenfitTrack::GenfitTrack(const edm4hep::Track& track, const bool skipTrackOrderi
                          const dd4hep::DDSegmentation::BitFieldCoder* decoder,
                          const GenfitInterface::GenfitField* fieldMap)
     : m_originalTrack(track), m_posInit(0., 0., 0.), m_momInit(0., 0., 0.), m_covInit(6), m_genfitTrackRep(nullptr),
-      m_genfitTrack(nullptr), m_edm4hepTrack(),
-
-      m_wire_info(wire_info), m_dc_decoder(decoder), m_fieldMap(fieldMap)
+      m_genfitTrack(nullptr), m_edm4hepTrack(), m_wire_info(wire_info), m_dc_decoder(decoder), m_fieldMap(fieldMap)
 
 {
 
@@ -36,7 +36,10 @@ GenfitTrack::GenfitTrack(const edm4hep::Track& track, const bool skipTrackOrderi
   OrderHits(track, skipTrackOrdering);
 }
 
-GenfitTrack::~GenfitTrack() {}
+GenfitTrack::~GenfitTrack() {
+  // genfit::Track owns its TrackReps, TrackPoints, and measurements.
+  delete m_genfitTrack;
+}
 
 /**
  * @brief Check if required Genfit components are properly initialized.
@@ -117,9 +120,18 @@ void GenfitTrack::OrderHits(const edm4hep::Track& track, bool skipTrackOrdering)
   // Sort hits along the track
   std::ranges::sort(distIndex, {}, &std::pair<float, std::size_t>::first);
 
-  m_edm4hepTrack = edm4hep::MutableTrack();
+  bool first = true;
   for (const auto& [_, idx] : distIndex) {
-    m_edm4hepTrack.addToTrackerHits(hits[idx]);
+    const auto& hit = hits[idx];
+    auto pos = hit.getPosition();
+    m_edm4hepTrack.addToTrackerHits(hit);
+
+    if (first) {
+      m_FirstHit_referencePoint = TVector3(pos.x * dd4hep::mm, pos.y * dd4hep::mm, pos.z * dd4hep::mm);
+      first = false;
+    }
+
+    m_LastHit_referencePoint = TVector3(pos.x * dd4hep::mm, pos.y * dd4hep::mm, pos.z * dd4hep::mm);
   }
 }
 
@@ -177,7 +189,7 @@ void GenfitTrack::OrderHits(const edm4hep::Track& track, bool skipTrackOrdering)
  *        - The covariance matrix is:
  *            - first reconstructed in helix parameter space
  *            - then transformed to Cartesian coordinates via
- *              `CovarianceMatrixHelixToCartesian`.
+ *              `InitialCovarianceMatrixHelixToCartesian`.
  *
  *    - InitializationType == 3 (custom user-defined):
  *        - Uses user-provided `Init_position` and `Init_momentum`.
@@ -269,7 +281,6 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
     auto pos2 = hits[1].getPosition();
 
     TVector3 p1(pos1.x * dd4hep::mm, pos1.y * dd4hep::mm, pos1.z * dd4hep::mm);
-
     TVector3 p2(pos2.x * dd4hep::mm, pos2.y * dd4hep::mm, pos2.z * dd4hep::mm);
 
     // Seed definition
@@ -300,10 +311,8 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
     double Bz = m_fieldMap->getBz(firstHitVec) / (dd4hep::tesla / dd4hep::kilogauss); // From kilogauss to Tesla
 
     // Optional reference point update
-    if (UseFirstHitAsReference || RadiusForDisplacedTracking > 0.) {
-      if (UseFirstHitAsReference || firstHitVec.Mag() > RadiusForDisplacedTracking) {
-        m_VP_referencePoint = firstHitVec;
-      }
+    if (UseFirstHitAsReference || (RadiusForDisplacedTracking > 0. && firstHitVec.Mag() > RadiusForDisplacedTracking)) {
+      m_VP_referencePoint = firstHitVec;
     }
 
     HelperInitialization initInfo = ComputeInitialParameters(Bz);
@@ -335,9 +344,12 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
         double Bz =
             m_fieldMap->getBz(m_VP_referencePoint) / (dd4hep::tesla / dd4hep::kilogauss); // From kilogauss to Tesla
 
-        HelperInitialization initInfo = ComputeInitialParameters(Bz);
-        m_posInit = initInfo.Position;
-        m_charge_hypothesis = initInfo.Charge;
+        // Reconstruct the PCA described by this exact TrackState (here phi is assumed to be equal to phi0 because the
+        // initial position is the PCA to VP)
+        m_posInit = TVector3(m_VP_referencePoint.X() - ts.D0 * std::sin(ts.phi) * dd4hep::mm,
+                             m_VP_referencePoint.Y() + ts.D0 * std::cos(ts.phi) * dd4hep::mm,
+                             m_VP_referencePoint.Z() + ts.Z0 * dd4hep::mm);
+        m_charge_hypothesis = (Bz / ts.omega >= 0.) ? 1 : -1;
 
         // Helix -> momentum conversion
         double pT = ConversionUnits::a_lcio * std::abs(Bz) / std::abs(ts.omega);
@@ -364,23 +376,8 @@ void GenfitTrack::InitializeTrack(double RadiusForDisplacedTracking, bool UseFir
           }
         }
 
-        // Conversion factors:
-        // d0 : mm -> cm
-        // phi0 : unchanged
-        // omega : 1/mm -> 1/cm => x10
-        // z0 : mm -> cm        => x0.1
-        // tanLambda : unchanged
-
-        double scale[5] = {dd4hep::mm, dd4hep::cm, 1. / dd4hep::mm, dd4hep::mm, dd4hep::cm};
-        for (int i = 0; i < 5; ++i) {
-          for (int j = 0; j < 5; ++j) {
-            C_helix(i, j) *= scale[i] * scale[j];
-          }
-        }
-
-        // Convert to Cartesian covariance
-        m_covInit = CovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint,
-                                                     m_charge_hypothesis, Bz);
+        m_covInit = InitialCovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint,
+                                                            m_charge_hypothesis, Bz);
       }
     }
 
@@ -506,6 +503,9 @@ void GenfitTrack::LimitNumberHits(double epsilon, int smoothWindow) {
     int idx_fill_track = 0;
     auto temp_hits = temp_track.getTrackerHits();
     for (const auto& hit : temp_hits) {
+
+      auto pos = hit.getPosition();
+      m_LastHit_referencePoint = TVector3(pos.x * dd4hep::mm, pos.y * dd4hep::mm, pos.z * dd4hep::mm);
       m_edm4hepTrack.addToTrackerHits(hit);
       ++idx_fill_track;
       if (idx_fill_track >= maxHit)
@@ -564,7 +564,7 @@ void GenfitTrack::LimitNumberHits(double epsilon, int smoothWindow) {
  *
  * @param Bz Magnetic field component along the z axis.
  * @param Charge Particle charge hypothesis (+1 or -1).
- * @param sigma_d0 Optional uncertainty on d0 [cm] (default 0.05).
+ * @param sigma_d0 Optional uncertainty on d0 [mm] (default 0.05).
  * @param sigma_phi Optional uncertainty on phi [rad] (default 0.1).
  * @param omega_factor Scaling factor for curvature uncertainty (default 0.5).
  * @param z0_factor Scaling factor for z0 uncertainty (default 0.1).
@@ -580,7 +580,7 @@ TMatrixDSym GenfitTrack::ComputeInitialCovarianceMatrix(double Bz, int Charge, s
   TMatrixDSym C_helix(5);
   C_helix.Zero();
 
-  // d0 (in cm)
+  // d0 (in mm)
   double sd0 = sigma_d0.value_or(0.05);
   C_helix(0, 0) = sd0 * sd0;
 
@@ -588,22 +588,21 @@ TMatrixDSym GenfitTrack::ComputeInitialCovarianceMatrix(double Bz, int Charge, s
   double sphi = sigma_phi.value_or(0.1);
   C_helix(1, 1) = sphi * sphi;
 
-  // omega (in 1/cm)
+  // omega (in 1/mm)
   double pt = m_momInit.Perp();
-  double omega = std::abs(ConversionUnits::a_lcio * Bz / pt * dd4hep::mm); // in 1/cm
+  double omega = std::abs(ConversionUnits::a_lcio * Bz / pt);
   C_helix(2, 2) = std::pow(omega_factor.value_or(0.5) * omega, 2);
 
-  // z0 (in cm)
-  double z0_scale = std::abs(m_posInit.Z());
+  // z0 relative to the track-parameter reference point, in mm.
+  double z0_scale = std::abs((m_posInit.Z() - m_VP_referencePoint.Z()) / dd4hep::mm);
   C_helix(3, 3) = std::pow(z0_factor.value_or(0.1) * z0_scale, 2);
 
   // tanLambda
   double stl = sigma_tanLambda.value_or(0.1);
   C_helix(4, 4) = stl * stl;
 
-  // Convert to Cartesian covariance
   TMatrixDSym covState =
-      CovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint, Charge, Bz);
+      InitialCovarianceMatrixHelixToCartesian(C_helix, m_posInit, m_momInit, m_VP_referencePoint, Charge, Bz);
 
   return covState;
 }
@@ -775,7 +774,6 @@ GenfitTrack::HelperInitialization GenfitTrack::ComputeInitialParameters(double B
 void GenfitTrack::CreateGenFitTrack(int particle_hypotesis, int debug_lvl) {
 
   delete m_genfitTrack;
-  delete m_genfitTrackRep;
   m_genfitTrack = nullptr;
   m_genfitTrackRep = nullptr;
 
@@ -851,14 +849,16 @@ void GenfitTrack::CreateGenFitTrack(int particle_hypotesis, int debug_lvl) {
  * track state based on the fitted position and momentum, taking into account the
  * assumed charge hypothesis and magnetic field.
  *
+ * @param fittedHits Output collection of fitted tracker hits after filtering (it is not updated if no filtering is
+ * applied).
  * @param FitterType Fitting strategy to use (https://indico.cern.ch/event/258092/papers/1588579/files/4253-genfit.pdf):
  *        - "DAF"        : Deterministic Annealing Filter
  *        - "KALMAN"     : Standard Kalman filter
  *        - "KALMAN_REF" : Kalman filter with reference track
- * @param debug_lvl   Verbosity level for debug output
- *                       - 0 = silent,
- *                       - 1 = fitter printout
- *                       - 2 = fitter printout + fit results
+ * @param debug_lvl   Gaudi-compatible verbosity level for debug output
+ *                       - 0 or >= 3 = silent
+ *                       - 2 = fit results, track states, and fit failures
+ *                       - 1 = level 2 output + detailed fitter information
  * @param Beta_init   Initial annealing parameter (only for DAF, default = 100)
  * @param Beta_final  Final annealing parameter (only for DAF, default = 0.1)
  * @param Beta_steps  Number of annealing steps (only for DAF, default = 10)
@@ -869,9 +869,13 @@ void GenfitTrack::CreateGenFitTrack(int particle_hypotesis, int debug_lvl) {
  * @note If any exception occurs during fitting or state extrapolation, the function
  *       returns false and does not update the track.
  */
-bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::optional<double> Beta_init = 100.,
-                      std::optional<double> Beta_final = 0.1, std::optional<int> Beta_steps = 10,
-                      std::optional<bool> FilterHits = true) {
+bool GenfitTrack::Fit(edm4hep::TrackerHitPlaneCollection& fittedHits, std::string FitterType = "DAF", int debug_lvl = 0,
+                      std::optional<double> Beta_init = 100., std::optional<double> Beta_final = 0.1,
+                      std::optional<int> Beta_steps = 10, std::optional<bool> FilterHits = true) {
+
+  const bool showFitDiagnostics = (debug_lvl == 1 || debug_lvl == 2);
+  const bool showFitterDiagnostics = (debug_lvl == 1);
+  ScopedFitDiagnostics fitDiagnostics(!showFitDiagnostics);
 
   edm4hep::Track Track_temp = m_edm4hepTrack;
   for (size_t i = 0; i < Track_temp.trackStates_size(); ++i) {
@@ -904,10 +908,15 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
     throw std::invalid_argument("Unknown fit method: " + FitterType);
   }
 
-  int debug_lvl_fit = debug_lvl;
-  if (debug_lvl > 1)
-    debug_lvl_fit = 0;
-  genfitFitter->setDebugLvl(debug_lvl_fit);
+  genfitFitter->setDebugLvl(showFitterDiagnostics ? 1 : 0);
+
+  // Reset the global TGeoManager navigator to a canonical state before fitting.
+  // The navigator (current node, point, direction, safety/step caches) is process-global
+  // and is mutated by every material lookup during extrapolation. Without this reset,
+  // the material resolved for on-boundary points can depend on the track fitted
+  // previously (even in an earlier event), making fit results order-dependent.
+  gGeoManager->CdTop();
+  gGeoManager->FindNode(m_posInit.X(), m_posInit.Y(), m_posInit.Z()); // seed position, in cm
 
   // Process track
   genfit::Track genfitTrack = *m_genfitTrack;
@@ -917,9 +926,11 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
 
     genfitFitter->processTrackWithRep(&genfitTrack, trackRep);
 
-  } catch (const std::exception& e) {
+  } catch (const genfit::Exception& e) {
 
-    std::cerr << "Exception during track fitting: " << e.what() << std::endl;
+    if (showFitDiagnostics) {
+      std::cerr << "Exception during track fitting: " << e.what() << std::endl;
+    }
     m_edm4hepTrack.setChi2(-1);
     m_edm4hepTrack.setNdf(-1);
 
@@ -1028,7 +1039,7 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
           double err_v = std::sqrt(var_v);
 
           // Create a new fitted hit object and set its position
-          auto hit3D = m_fittedHits.create();
+          auto hit3D = fittedHits.create();
           hit3D.setPosition(edm4hep::Vector3d(pos.X() / dd4hep::mm, pos.Y() / dd4hep::mm, pos.Z() / dd4hep::mm));
 
           // Set the 3x3 position covariance matrix in EDM4hep format
@@ -1051,35 +1062,58 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
           hit3D.setU(edm4hepU);
           hit3D.setV(edm4hepV);
 
-          hit3D.setType(1); // Mark as accepted hit
           m_trackWithFit.addToTrackerHits(hit3D);
-        } else {
-          // Create a placeholder for the rejected hit
-          auto hit3D = m_fittedHits.create();
-          hit3D.setType(0); // Mark as rejected hit
         }
       }
     }
 
+    // getFittedState() averages the forward/backward Kalman states and can throw
+    // a genfit::Exception (e.g. an ill-conditioned covariance)
     genfit::MeasuredStateOnPlane fittedState;
 
-    // trackState First Hit
-    fittedState = genfitTrack.getFittedState();
-    edm4hep::TrackState trackStateFirstHit = UpdateTrackState(fittedState, edm4hep::TrackState::AtFirstHit);
+    // trackState firstHit
+    try {
+      fittedState = genfitTrack.getFittedState();
+    } catch (const genfit::Exception& e) {
+      if (showFitDiagnostics) {
+        std::cerr << "Exception retrieving fitted state: " << e.what() << std::endl;
+      }
+      m_edm4hepTrack.setChi2(-1);
+      m_edm4hepTrack.setNdf(-1);
+      m_trackWithFit.setChi2(-1);
+      m_trackWithFit.setNdf(-1);
+      return false;
+    }
+    edm4hep::TrackState trackStateFirstHit =
+        UpdateTrackState(fittedState, m_FirstHit_referencePoint, edm4hep::TrackState::AtFirstHit);
 
     // trackState lastHit
-    fittedState = genfitTrack.getFittedState(genfitTrack.getNumPoints() - 1);
-    edm4hep::TrackState trackStateLastHit = UpdateTrackState(fittedState, edm4hep::TrackState::AtLastHit);
+    try {
+      fittedState = genfitTrack.getFittedState(genfitTrack.getNumPoints() - 1);
+    } catch (const genfit::Exception& e) {
+      if (showFitDiagnostics) {
+        std::cerr << "Exception retrieving fitted state: " << e.what() << std::endl;
+      }
+      m_edm4hepTrack.setChi2(-1);
+      m_edm4hepTrack.setNdf(-1);
+      m_trackWithFit.setChi2(-1);
+      m_trackWithFit.setNdf(-1);
+      return false;
+    }
+    edm4hep::TrackState trackStateLastHit =
+        UpdateTrackState(fittedState, m_LastHit_referencePoint, edm4hep::TrackState::AtLastHit);
 
     // Extrapolation to IP
     genfit::TrackPoint* tp = genfitTrack.getPointWithFitterInfo(0);
     auto* fi = static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(trackRep));
-    fittedState = fi->getFittedState(true);
 
     try {
+      fittedState = fi->getFittedState(true);
       trackRep->extrapolateToLine(fittedState, TVector3(0, 0, 0), TVector3(0, 0, 1));
-    } catch (const std::exception& e) {
-      std::cerr << "Exception during extrapolation to IP: " << e.what() << std::endl;
+    } catch (const genfit::Exception& e) {
+      if (showFitDiagnostics) {
+        std::cerr << "Exception during extrapolation to IP: " << e.what() << std::endl;
+      }
 
       m_edm4hepTrack.setChi2(-1);
       m_edm4hepTrack.setNdf(-1);
@@ -1088,10 +1122,9 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
 
       return false;
     }
+    edm4hep::TrackState trackStateIP = UpdateTrackState(fittedState, m_VP_referencePoint, edm4hep::TrackState::AtIP);
 
-    edm4hep::TrackState trackStateIP = UpdateTrackState(fittedState, edm4hep::TrackState::AtIP);
-
-    if (debug_lvl == 2) {
+    if (showFitDiagnostics) {
 
       std::cout << "GenfitTrack    DEBUG : TrackState at IP: " << std::endl;
       std::cout << "GenfitTrack    DEBUG :  D0: " << trackStateIP.D0 << " mm" << std::endl;
@@ -1156,35 +1189,32 @@ bool GenfitTrack::Fit(std::string FitterType = "DAF", int debug_lvl = 0, std::op
  * @brief Propagation of the covariance matrix from helix-parameter representation to Cartesian coordinate
  * representation
  *
- * @param C_helix        Covariance Matrix in helix-basis (cm and GeV units)
- * @param Position_cm    Inizial Position in cm
- * @param Momentum_gev   Initial Momentum in gev/c
- * @param RefPoint_cm    Reference position (e.g. IP)
- * @param Charge         Charge hypothesis
- * @param Bz             Bz
+ * @param C_helix Covariance matrix in native EDM4hep helix units: (mm, rad, 1/mm, mm, dimensionless)
+ * @param positionCm Nominal Cartesian position in GENFIT cm.
+ * @param momentumGeV Nominal Cartesian momentum in GeV.
+ * @param referencePointCm Reference point in GENFIT cm.
+ * @param charge Charge hypothesis.
+ * @param magneticFieldTesla Longitudinal magnetic field in T.
  *
- * @return Covariance matrix in cartesian-basis
+ * @return Covariance matrix in cartesian-basis (cm and GeV units)
  */
-TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_helix, // 5x5
-                                                          TVector3 Position_cm, TVector3 Momentum_gev,
-                                                          TVector3 RefPoint_cm, int Charge, double Bz) {
+TMatrixDSym GenfitTrack::InitialCovarianceMatrixHelixToCartesian(const TMatrixDSym& C_helix, const TVector3& positionCm,
+                                                                 const TVector3& momentumGeV,
+                                                                 const TVector3& referencePointCm, int charge,
+                                                                 double magneticFieldTesla) {
 
-  double x_PCA = Position_cm.X();
-  double y_PCA = Position_cm.Y();
-
-  double px = Momentum_gev.X();
-  double py = Momentum_gev.Y();
-  double pz = Momentum_gev.Z();
-
-  double pt = Momentum_gev.Perp();
-  double phi0 = std::atan2(py, px);
-
-  double d0 = -(RefPoint_cm.X() - x_PCA) * sin(phi0) + (RefPoint_cm.Y() - y_PCA) * cos(phi0);
-
-  double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)) * dd4hep::mm; // in 1/cm
-
-  if (Bz * Charge < 0)
-    omega = -omega;
+  const double px = momentumGeV.X();
+  const double py = momentumGeV.Y();
+  const double pz = momentumGeV.Z();
+  const double pt = momentumGeV.Perp();
+  const double phi = momentumGeV.Phi();
+  const double xMm = positionCm.X() / dd4hep::mm;
+  const double yMm = positionCm.Y() / dd4hep::mm;
+  const double referenceXMm = referencePointCm.X() / dd4hep::mm;
+  const double referenceYMm = referencePointCm.Y() / dd4hep::mm;
+  const double d0Mm = -(xMm - referenceXMm) * std::sin(phi) + (yMm - referenceYMm) * std::cos(phi);
+  const double omegaPerMm =
+      (magneticFieldTesla * charge < 0. ? -1. : 1.) * std::abs(ConversionUnits::a_lcio * magneticFieldTesla / pt);
 
   // --- Jacobian (6x5) ---
   TMatrixD J(6, 5);
@@ -1192,73 +1222,66 @@ TMatrixDSym GenfitTrack::CovarianceMatrixHelixToCartesian(const TMatrixDSym& C_h
 
   // These definitions are taken from
   // https://flc.desy.de/lcnotes/notes/localfsExplorer_read?currentPath=/afs/desy.de/group/flc/lcnotes/LC-DET-2006-004.pdf
+  //
+  // d0 = -(x_PCA - Xr)*sin(phi0) + (y_PCA - Yr)*cos(phi0)
+  // => x_PCA = Xr - d0*sin(phi0), y_PCA = Yr + d0*cos(phi0)   [all in mm]
 
-  // The transverse impact parameter d0 is defined as the projection of the
-  // displacement vector between the reference point Pr and the PCA P0
-  // onto the unit normal vector to the track direction at the PCA.
-  //
-  // d = P0 - Pr = (x_PCA - Xr, y_PCA - Yr)
-  //
-  // n_PCA = (-sin(phi0), cos(phi0))
-  //
-  // Therefore:
-  //
-  // d0 = n_PCA · d
-  //    = (x_PCA - Xr)(-sin(phi0))
-  //      + (y_PCA - Yr)(cos(phi0))
-  //
-  // Since the displacement vector from the reference point to the PCA is
-  // parallel to the normal direction:
-  //
-  // P0 - Pr = d0 * n_PCA
-  //
-  // the PCA coordinates become:
-  //
-  // x_PCA = Xr - d0 * sin(phi0)
-  // y_PCA = Yr + d0 * cos(phi0)
-  J(0, 0) = -sin(phi0);      // dx / dd0
-  J(0, 1) = -d0 * cos(phi0); // dx / dphi0
-  J(0, 2) = 0.0;             // dx / domega
-  J(0, 3) = 0.0;             // dx / dz0
-  J(0, 4) = 0.0;             // dx / dtanLambda
+  J(0, 0) = -sin(phi);        // dx / dd0
+  J(0, 1) = -d0Mm * cos(phi); // dx / dphi0
+  J(0, 2) = 0.0;              // dx / domega
+  J(0, 3) = 0.0;              // dx / dz0
+  J(0, 4) = 0.0;              // dx / dtanLambda
 
-  J(1, 0) = cos(phi0);       // dy / dd0
-  J(1, 1) = -d0 * sin(phi0); // dy / dphi0
-  J(1, 2) = 0.0;             // dy / domega
-  J(1, 3) = 0.0;             // dy / dz0
-  J(1, 4) = 0.0;             // dy / dtanLambda
+  J(1, 0) = cos(phi);         // dy / dd0
+  J(1, 1) = -d0Mm * sin(phi); // dy / dphi0
+  J(1, 2) = 0.0;              // dy / domega
+  J(1, 3) = 0.0;              // dy / dz0
+  J(1, 4) = 0.0;              // dy / dtanLambda
 
-  // z = z_PCA = P^0_z = z0 + P^r_z
+  // z = z_PCA = z0 + P^r_z   [mm]
   J(2, 0) = 0.0; // dz / dd0
   J(2, 1) = 0.0; // dz / dphi0
   J(2, 2) = 0.0; // dz / domega
   J(2, 3) = 1.0; // dz / dz0
   J(2, 4) = 0.0; // dz / dtanLambda
 
-  // px = pt * cos(phi0) = a * Bz / omega * cos(phi0)
-  J(3, 0) = 0.0;         // dpx / dd0
-  J(3, 1) = -py;         // dpx / dphi0
-  J(3, 2) = -px / omega; // dpx / domega
-  J(3, 3) = 0.0;         // dpx / dz0
-  J(3, 4) = 0.0;         // dpx / dtanLambda
+  // px = pt * cos(phi)
+  J(3, 0) = 0.0;              // dpx / dd0
+  J(3, 1) = -py;              // dpx / dphi0
+  J(3, 2) = -px / omegaPerMm; // dpx / domega
+  J(3, 3) = 0.0;              // dpx / dz0
+  J(3, 4) = 0.0;              // dpx / dtanLambda
 
-  // py = pt * sin(phi0) = a * Bz / omega * sin(phi0)
-  J(4, 0) = 0.0;         // dpy / dd0
-  J(4, 1) = px;          // dpy / dphi0
-  J(4, 2) = -py / omega; // dpy / domega
-  J(4, 3) = 0.0;         // dpy / dz0
-  J(4, 4) = 0.0;         // dpy / dtanLambda
+  // py = pt * sin(phi)
+  J(4, 0) = 0.0;              // dpy / dd0
+  J(4, 1) = px;               // dpy / dphi0
+  J(4, 2) = -py / omegaPerMm; // dpy / domega
+  J(4, 3) = 0.0;              // dpy / dz0
+  J(4, 4) = 0.0;              // dpy / dtanLambda
 
-  // pz = pt * tanLambda = a * Bz / omega * tanLambda = p * cos(theta) = p * cos(cot^-1(tanLambda))
-  J(5, 0) = 0.0;         // dpz / dd0
-  J(5, 1) = 0.0;         // dpz / dphi0
-  J(5, 2) = -pz / omega; // dpz / domega
-  J(5, 3) = 0.0;         // dpz / dz0
-  J(5, 4) = pt;          // dpz / dtanLambda
+  // pz = pt * tanLambda
+  J(5, 0) = 0.0;              // dpz / dd0
+  J(5, 1) = 0.0;              // dpz / dphi0
+  J(5, 2) = -pz / omegaPerMm; // dpz / domega
+  J(5, 3) = 0.0;              // dpz / dz0
+  J(5, 4) = pt;               // dpz / dtanLambda
 
-  // --- Compute C_cart = J * C_helix * J^T ---
+  // --- Compute C_cart = J * C_helix * J^T   (positions in mm, momenta in GeV) ---
   TMatrixD Jt(TMatrixD::kTransposed, J);
   TMatrixD tmp = J * C_helix * Jt;
+
+  // Convert position-related blocks back from mm to cm, to match Position_cm's units
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      tmp(i, j) *= dd4hep::mm * dd4hep::mm;
+    }
+  }
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 3; j < 6; ++j) {
+      tmp(i, j) *= dd4hep::mm;
+      tmp(j, i) *= dd4hep::mm;
+    }
+  }
 
   TMatrixDSym C_cart(6);
   C_cart.Zero();
@@ -1303,13 +1326,25 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
   double RefY_mm = RefPoint_cm.Y() / dd4hep::mm;
 
   double pt = Momentum_gev.Perp();
+  double pt2 = std::pow(pt, 2);
 
   double phi0 = std::atan2(py, px);
   double tanLambda = pz / pt;
-  double omega = (std::abs(ConversionUnits::a_lcio * Bz / pt)); // in 1/mm
+  double omega = (Bz * Charge < 0 ? -1.0 : 1.0) * std::abs(ConversionUnits::a_lcio * Bz / pt); // in 1/mm
 
-  if (Bz * Charge < 0)
-    omega = -omega;
+  // Convert covariance matrix from cm/GeV to mm/GeV
+  TMatrixDSym C_cart(C_cartesian);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      C_cart(i, j) *= 1 / (dd4hep::mm * dd4hep::mm);
+    }
+  }
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 3; j < 6; ++j) {
+      C_cart(i, j) *= 1 / dd4hep::mm;
+      C_cart(j, i) *= 1 / dd4hep::mm;
+    }
+  }
 
   // --- Jacobian (5x6) ---
   TMatrixD J(5, 6);
@@ -1318,28 +1353,27 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
   // These definitions are taken from
   // https://flc.desy.de/lcnotes/notes/localfsExplorer_read?currentPath=/afs/desy.de/group/flc/lcnotes/LC-DET-2006-004.pdf
 
-  // d0 = -(Xr - x)*sin(phi0) + (Yr - y)*cos(phi0)
-  J(0, 0) = sin(phi0);  // dd0 / dx
-  J(0, 1) = -cos(phi0); // dd0 / dy
+  // d0 = -(x - Xr)*sin(phi0) + (y - Yr)*cos(phi0)
+  J(0, 0) = -sin(phi0); // dd0 / dx
+  J(0, 1) = cos(phi0);  // dd0 / dy
   J(0, 2) = 0.0;        // dd0 / dz
 
   // chain rule via phi0 = atan2(py, px)
-  double dd0_dphi = -(RefX_mm - x_PCA_mm) * cos(phi0) - (RefY_mm - y_PCA_mm) * sin(phi0);
+  double dd0_dphi = (RefX_mm - x_PCA_mm) * cos(phi0) + (RefY_mm - y_PCA_mm) * sin(phi0);
 
-  J(0, 3) = dd0_dphi * (-py / (pt * pt)); // dd0 / dpx
-  J(0, 4) = dd0_dphi * (px / (pt * pt));  // dd0 / dpy
-  J(0, 5) = 0.0;                          // dd0 / dpz
+  J(0, 3) = dd0_dphi * (-py / pt2); // dd0 / dpx
+  J(0, 4) = dd0_dphi * (px / pt2);  // dd0 / dpy
+  J(0, 5) = 0.0;                    // dd0 / dpz
 
   // phi0 = atan2(py, px);
-  J(1, 0) = 0.0;                   // dphi0 / dx
-  J(1, 1) = 0.0;                   // dphi0 / dy
-  J(1, 2) = 0.0;                   // dphi0 / dz
-  J(1, 3) = -py / std::pow(pt, 2); // dphi0 / dpx
-  J(1, 4) = px / std::pow(pt, 2);  // dphi0 / dpy
-  J(1, 5) = 0.0;                   // dphi0 / dpz
+  J(1, 0) = 0.0;       // dphi0 / dx
+  J(1, 1) = 0.0;       // dphi0 / dy
+  J(1, 2) = 0.0;       // dphi0 / dz
+  J(1, 3) = -py / pt2; // dphi0 / dpx
+  J(1, 4) = px / pt2;  // dphi0 / dpy
+  J(1, 5) = 0.0;       // dphi0 / dpz
 
   // omega = q * a * Bz / pt, with pt = sqrt(px^2 + py^2)
-  double pt2 = px * px + py * py;
   J(2, 0) = 0.0;               // domega / dx_PCA
   J(2, 1) = 0.0;               // domega / dy_PCA
   J(2, 2) = 0.0;               // domega / dz_PCA
@@ -1356,16 +1390,16 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
   J(3, 5) = 0.0; // dz0 / dpz
 
   // tanLambda = pz / pt
-  J(4, 0) = 0.0;                               // dtanLambda / dx_PCA
-  J(4, 1) = 0.0;                               // dtanLambda / dy_PCA
-  J(4, 2) = 0.0;                               // dtanLambda / dz_PCA
-  J(4, 3) = -tanLambda * px / std::pow(pt, 2); // dtanLambda / dpx
-  J(4, 4) = -tanLambda * py / std::pow(pt, 2); // dtanLambda / dpy
-  J(4, 5) = 1.0 / pt;                          // dtanLambda / dpz
+  J(4, 0) = 0.0;                   // dtanLambda / dx_PCA
+  J(4, 1) = 0.0;                   // dtanLambda / dy_PCA
+  J(4, 2) = 0.0;                   // dtanLambda / dz_PCA
+  J(4, 3) = -tanLambda * px / pt2; // dtanLambda / dpx
+  J(4, 4) = -tanLambda * py / pt2; // dtanLambda / dpy
+  J(4, 5) = 1.0 / pt;              // dtanLambda / dpz
 
-  // --- Compute C_cart = J * C_helix * J^T ---
+  // --- Compute C_helix = J * C_cart * J^T ---
   TMatrixD Jt(TMatrixD::kTransposed, J);
-  TMatrixD tmp = J * C_cartesian * Jt;
+  TMatrixD tmp = J * C_cart * Jt;
 
   TMatrixDSym C_helix(5);
   C_helix.Zero();
@@ -1392,9 +1426,7 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
  *
  * The procedure includes:
  *   - Extraction of position, momentum, and covariance from the Genfit state
- *   - Optional inversion of the momentum direction for states at the Interaction Point (IP)
  *   - Retrieval of the local magnetic field (Bz) at the track position
- *   - Computation of the Point of Closest Approach (PCA) to a reference point
  *   - Derivation of helix parameters:
  *       - d0          : transverse impact parameter (mm)
  *       - z0          : longitudinal impact parameter (mm)
@@ -1403,19 +1435,15 @@ TMatrixDSym GenfitTrack::CovarianceMatrixCartesianToHelix(const TMatrixDSym& C_c
  *       - tanLambda   : dip angle (pz / pt)
  *   - Assignment of the reference point and track state location
  *
- * The PCA and associated parameters are computed assuming a helical trajectory
- * in a magnetic field aligned along the z-axis.
- *
- * @param Edm4hepTrackState Output track state to be updated
  * @param MeasuredState Genfit measured state containing fitted position and momentum
+ * @param ReferencePoint Reference point position [cm]
  * @param location Location identifier for the track state (e.g. AtIP, AtFirstHit, AtLastHit)
  *
- * @note The momentum is reversed for states at the Interaction Point (AtIP) to ensure
- *       a consistent track parameter convention.
  * @note The magnetic field is retrieved at the current position and converted to Tesla.
  * @note The curvature sign (omega) depends on the assumed particle charge hypothesis.
  */
-edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane MeasuredState, int location) {
+edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane MeasuredState, TVector3 ReferencePoint,
+                                                  int location) {
 
   edm4hep::TrackState Edm4hepTrackState;
 
@@ -1424,21 +1452,18 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
 
   MeasuredState.getPosMomCov(gen_position, gen_momentum, covariancePosMom);
 
-  double x_ref = gen_position.X(); // cm
-  double y_ref = gen_position.Y(); // cm
-  double z_ref = gen_position.Z(); // cm
-  double pz = gen_momentum.Z();    // gev
-  double pt = gen_momentum.Perp(); // gev
+  double x_reco = gen_position.X(); // cm
+  double y_reco = gen_position.Y(); // cm
+  double z_reco = gen_position.Z(); // cm
+  double pz = gen_momentum.Z();     // gev
+  double pt = gen_momentum.Perp();  // gev
+  double phi = gen_momentum.Phi();
+
+  double d0 =
+      (-(x_reco - ReferencePoint.X()) * std::sin(phi) + (y_reco - ReferencePoint.Y()) * std::cos(phi)) / dd4hep::mm;
+  double z0 = z_reco - ReferencePoint.Z();
 
   double Bz = m_fieldMap->getBz(gen_position) / (dd4hep::tesla / dd4hep::kilogauss); // From kilogauss to Tesla
-  auto infoComputeD0Z0_firstHit =
-      PCAInfo(gen_position, gen_momentum, m_charge_hypothesis, m_VP_referencePoint, Bz); // in cm
-
-  double d0 = ((-(m_VP_referencePoint.X() - infoComputeD0Z0_firstHit.PCA.X())) * sin(infoComputeD0Z0_firstHit.Phi0) +
-               (m_VP_referencePoint.Y() - infoComputeD0Z0_firstHit.PCA.Y()) * cos(infoComputeD0Z0_firstHit.Phi0)) /
-              dd4hep::mm;                                                                // mm
-  double z0 = (infoComputeD0Z0_firstHit.PCA.Z() - m_VP_referencePoint.Z()) / dd4hep::mm; // mm
-  double phi = gen_momentum.Phi();                                                       // rad
 
   double tanLambda = pz / pt;
   double omega = std::abs(ConversionUnits::a_lcio * Bz / pt);
@@ -1452,11 +1477,12 @@ edm4hep::TrackState GenfitTrack::UpdateTrackState(genfit::MeasuredStateOnPlane M
   Edm4hepTrackState.tanLambda = tanLambda;
   Edm4hepTrackState.time = 0.;
 
-  Edm4hepTrackState.referencePoint = edm4hep::Vector3f(x_ref / dd4hep::mm, y_ref / dd4hep::mm, z_ref / dd4hep::mm);
+  Edm4hepTrackState.referencePoint = edm4hep::Vector3f(ReferencePoint.X() / dd4hep::mm, ReferencePoint.Y() / dd4hep::mm,
+                                                       ReferencePoint.Z() / dd4hep::mm);
   Edm4hepTrackState.location = location;
 
-  TMatrixDSym CovHelix = CovarianceMatrixCartesianToHelix(covariancePosMom, gen_position, gen_momentum,
-                                                          m_VP_referencePoint, m_charge_hypothesis, Bz);
+  TMatrixDSym CovHelix = CovarianceMatrixCartesianToHelix(covariancePosMom, gen_position, gen_momentum, ReferencePoint,
+                                                          m_charge_hypothesis, Bz);
 
   // Conversion from TMatrixDSym(5x5) to lower-triangular packed format used in edm4hep::TrackState
   for (int i = 0; i < 5; ++i) {


### PR DESCRIPTION
BEGINRELEASENOTES

- Corrected the units used in the Jacobian to ensure consistency between GENFIT and EDM4hep.
- Fixed broken associations between hits and tracks introduced during the filtering stage.
- Refactored the track-finding algorithm to discard tracks classified as noise. Only successfully reconstructed tracks are now written to the output file.
- Reset the global TGeoManager navigator to a canonical state before each fit. The navigator state is process-global and is modified by material lookups during track extrapolation. Without this reset, the material assigned to points located on geometry boundaries may depend on the previously fitted track, potentially from an earlier event, making the fit results dependent on processing order.
- Updated the TrackState objects at the first and last hits to use the measured hit positions as reference points when computing d0 and z0.
- Added exception handling around getFittedState after the GENFIT fit. A failure to retrieve the fitted state for a single track no longer terminates the entire process.
- Added the GenfitDebugLevel.h utility, including the ScopedFitDiagnostics RAII guard, to temporarily suppress GENFIT error and debug output during track fitting. The utility also filters the expected ROOT error emitted by TDecompChol::Decompose for non-positive-definite matrices, while forwarding all other ROOT diagnostics and automatically restoring the original stream buffers and error handler when leaving the fitting scope.

ENDRELEASENOTES

Hello!
I am opening this PR to address some bugs reported over the past few weeks. It also introduces a utility to suppress diagnostic messages generated by failed fit attempts. These messages remain available when debugLvl is set to DEBUG or VERBOSE.

Cheers,
Andrea