### PR TITLE
TrackdNdxDelphesBased Fix

### DIFF
--- a/Tracking/components/TrackdNdxDelphesBased.cpp
+++ b/Tracking/components/TrackdNdxDelphesBased.cpp
@@ -109,11 +109,15 @@ edm4hep::RecDqdxCollection TrackdNdxDelphesBased::operator()(const edm4hep::Trac
       double betagamma = momentum / mass;
       debug() << "MCParticle betagamma: " << betagamma << endmsg;
       // Check if betagamma is in valid range of delphes parametrisation (status: 16 June 2025)
-      if (betagamma < 0.5 || betagamma > 20000.0) {
-        warning() << "beta*gamma value outside of \"good\" range of delphes parametrisation (0.5-20000), dN/dx will be "
+      if (betagamma < 0.5 ) {
+        warning() << "beta*gamma value below \"good\" range of delphes parametrisation (0.5-10000), dN/dx will be "
                      "set to dummy value: "
                   << dummy_value << " clusters/mm" << endmsg;
         goto store_value;
+      } else if (betagamma > 10000) {
+        warning() << "beta*gamma value above \"good\" range of delphes parametrisation (0.5-10000), "
+                     "beta*gamma will be set to max value of 10000 as approximation." << endmsg;
+        betagamma = 9999.9; // 10000 is out of range already
       }
 
       // Get number of clusters per length from delphes

--- a/Tracking/components/TrackdNdxDelphesBased.cpp
+++ b/Tracking/components/TrackdNdxDelphesBased.cpp
@@ -116,7 +116,7 @@ edm4hep::RecDqdxCollection TrackdNdxDelphesBased::operator()(const edm4hep::Trac
         goto store_value;
       } else if (betagamma > 10000) {
         warning() << "beta*gamma value above \"good\" range of delphes parametrisation (0.5-10000), "
-                     "beta*gamma will be set to max value of 10000 as approximation." << endmsg;
+                     "beta*gamma will be set to max value as approximation." << endmsg;
         betagamma = 9999.9; // 10000 is out of range already
       }
 
@@ -124,6 +124,11 @@ edm4hep::RecDqdxCollection TrackdNdxDelphesBased::operator()(const edm4hep::Trac
       // Output from delphes function is in 1/m, so to convert to 1/mm we need to scale accordingly
       double nclusters_per_mm = m_delphesTrkUtil.Nclusters(betagamma, m_GasSel.value()) / 1000.0;
       debug() << "Number of clusters per mm: " << nclusters_per_mm << endmsg;
+      if (nclusters_per_mm < 1e-6) {
+        warning() << "Delphes number of clusters per mm calculation returned 0.0, dN/dx will be set to dummy value: "
+                  << dummy_value << " clusters/mm" << endmsg;
+        goto store_value;
+      }
 
       ///////////////////////
       // Track Information //

--- a/Tracking/components/TrackdNdxDelphesBased.cpp
+++ b/Tracking/components/TrackdNdxDelphesBased.cpp
@@ -109,14 +109,15 @@ edm4hep::RecDqdxCollection TrackdNdxDelphesBased::operator()(const edm4hep::Trac
       double betagamma = momentum / mass;
       debug() << "MCParticle betagamma: " << betagamma << endmsg;
       // Check if betagamma is in valid range of delphes parametrisation (status: 16 June 2025)
-      if (betagamma < 0.5 ) {
+      if (betagamma < 0.5) {
         warning() << "beta*gamma value below \"good\" range of delphes parametrisation (0.5-10000), dN/dx will be "
                      "set to dummy value: "
                   << dummy_value << " clusters/mm" << endmsg;
         goto store_value;
       } else if (betagamma > 10000) {
         warning() << "beta*gamma value above \"good\" range of delphes parametrisation (0.5-10000), "
-                     "beta*gamma will be set to max value as approximation." << endmsg;
+                     "beta*gamma will be set to max value as approximation."
+                  << endmsg;
         betagamma = 9999.9; // 10000 is out of range already
       }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Adapted and changed logic of accepted $\beta\gamma$ range in `TrackdNdxDelphesBased`

ENDRELEASENOTES

I recently noticed that the delphes accepted range for $\beta\gamma$ was lowered (whether intentionally or not, see https://github.com/delphes/delphes/issues/199) to $10000$.
Thus, in the [`run_digi_reco.py`](https://github.com/HEP-FCC/FCC-config/blob/main/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py) script in FCC-Config for `IDEA`, the 10 GeV electrons would silently be out of the range and produce `nclusters=0`.

This PR aligns the upper limit of accepted $\beta\gamma$ in `TrackdNdxDelphesBased` with the range from `delphes/TrkUtil`.
Also, the logic is slighty changed, so that if the value is above the range, it will set $\beta\gamma$ to the max value as an approximation. This way 10 GeV electrons will still produce clusters.

Cheers,
Andreas